### PR TITLE
OpenConceptLab/ocl_issues#2471 | Generalize bridge matching

### DIFF
--- a/src/components/map-projects/Candidates.jsx
+++ b/src/components/map-projects/Candidates.jsx
@@ -612,7 +612,7 @@ const Candidates = ({rowIndex, alert, setAlert, candidates, setShowItem, showIte
                 bucketId={`${rowIndex}-${algo.id}`}
                 noToolbar={i !== 0}
                 isFirst={i === 0}
-                bridge={algo.id === 'ocl-ciel-bridge'}
+                bridge={algo.type?.includes('bridge')}
                 scispacy={algo.id === 'ocl-scispacy-loinc'}
                 collapsed={collapsed}
                 onCollapse={setCollapsed}

--- a/src/components/map-projects/Concept.jsx
+++ b/src/components/map-projects/Concept.jsx
@@ -184,7 +184,7 @@ const ConceptItem = ({_id, notClickable, isSelectedToShow, firstChild, lastChild
 
 
 const Concept = ({_id, firstChild, lastChild, concept, setShowHighlights, isShown, onCardClick, onMap, isSelectedForMap, noScore, repoVersion, isAIRecommended, AIRecommendedCandidateId, sx, notClickable, noSynonymPrefix, locales, showAlgo, candidatesScore, algoScoreFirst, asTarget, conceptCache}) => {
-  const bridge = concept?.search_meta?.algorithm === 'ocl-ciel-bridge'
+  const bridge = concept?.search_meta?.algorithm?.includes('bridge')
   const scispacy = concept?.search_meta?.algorithm === 'ocl-scispacy-loinc'
   const id = concept?.version_url || concept?.url || concept?.id
   const isSelectedToShow = isShown ? isShown(id) : false

--- a/src/components/map-projects/ConfigurationForm.jsx
+++ b/src/components/map-projects/ConfigurationForm.jsx
@@ -46,7 +46,7 @@ const VisuallyHiddenInput = styled('input')({
 });
 
 
-const ConfigurationForm = ({ project, handleFileUpload, file, owner, setOwner, name, setName, description, setDescription, repo, onRepoChange, repoVersion, setRepoVersion, versions, mappedSources, targetSourcesFromRows, algosSelected, setAlgosSelected, sx, algos, validColumns, columns, isValidColumnValue, updateColumn, configure, setConfigure, columnVisibilityModel, setColumnVisibilityModel, onSave, isSaving, candidatesScore, onScoreChange, includeDefaultFilter, setIncludeDefaultFilter, filters, setFilters, locales, isLoadingLocales, setAIAssistantColumns, AIAssistantColumns, inAIAssistantGroup, lookupConfig, setLookupConfig, canBridge, canScispacy }) => {
+const ConfigurationForm = ({ project, handleFileUpload, file, owner, setOwner, name, setName, description, setDescription, repo, onRepoChange, repoVersion, setRepoVersion, versions, mappedSources, targetSourcesFromRows, algosSelected, setAlgosSelected, sx, algos, validColumns, columns, isValidColumnValue, updateColumn, configure, setConfigure, columnVisibilityModel, setColumnVisibilityModel, onSave, isSaving, candidatesScore, onScoreChange, includeDefaultFilter, setIncludeDefaultFilter, filters, setFilters, locales, isLoadingLocales, setAIAssistantColumns, AIAssistantColumns, inAIAssistantGroup, lookupConfig, setLookupConfig, canBridge, isCoreUser, canScispacy }) => {
   const { t } = useTranslation();
   const isLLMAlgoNotAllowed = !repoVersion?.match_algorithms?.includes('llm')
   const appliedLocales = filters?.locale ? filters?.locale?.split(',') : []
@@ -54,7 +54,7 @@ const ConfigurationForm = ({ project, handleFileUpload, file, owner, setOwner, n
     return algos.map(algo => {
       if(algo.type === 'ocl-semantic')
         algo.disabled = Boolean(isLLMAlgoNotAllowed)
-      else if(algo.type === 'ocl-ciel-bridge')
+      else if(['ocl-bridge', 'ocl-ciel-bridge'].includes(algo.type))
         algo.disabled = !canBridge
       else if(algo.type === 'ocl-scispacy')
         algo.disabled = !canScispacy
@@ -221,6 +221,7 @@ const ConfigurationForm = ({ project, handleFileUpload, file, owner, setOwner, n
         value={algosSelected}
         onChange={setAlgosSelected}
         repo={repoVersion}
+        isCoreUser={isCoreUser}
       />
       <>
         <Typography component="div" sx={{fontSize: '16px', fontWeight: 'bold', marginTop: '20px'}}>

--- a/src/components/map-projects/MapProject.jsx
+++ b/src/components/map-projects/MapProject.jsx
@@ -195,7 +195,7 @@ const MapProject = () => {
   const [repo, setRepo] = React.useState(false)
   const [repoVersion, setRepoVersion] = React.useState(false)
   const [mappedSources, setMappedSources] = React.useState([])
-  const [CIELMappedSources, setCIELMappedSources] = React.useState([])
+  const [bridgeMappedSources, setBridgeMappedSources] = React.useState({})
   const [locales, setLocales] = React.useState([])
   const [isLoadingLocales, setIsLoadingLocales] = React.useState(false)
   const [versions, setVersions] = React.useState([])
@@ -239,7 +239,8 @@ const MapProject = () => {
   const canScispacy = Boolean(canBridge && SCISPACY_API_URL && toggles.SCISPACY_LOINC_TOGGLE === true)
   const isMultiAlgo = algosSelected.length > 1
   const scispacyEnabled = find(algosSelected, {type: 'ocl-scispacy'})
-  const bridgeEnabled = find(algosSelected, {type: 'ocl-ciel-bridge'})
+  const bridgeAlgo = find(algosSelected, a => ['ocl-bridge', 'ocl-ciel-bridge'].includes(a.type))
+  const bridgeEnabled = Boolean(bridgeAlgo)
 
   const baseAlgos = useAlgos(t, toggles)
   const [apiAlgos, setApiAlgos] = React.useState([]);
@@ -257,8 +258,12 @@ const MapProject = () => {
         const response = await service.get();
         const _algos = response?.data?.results || []
         setApiAlgos(_algos);
-        if(find(_algos, {type: 'ocl-ciel-bridge'}))
-          fetchMappedSources('/orgs/CIEL/sources/CIEL/latest/', setCIELMappedSources)
+        const bridgeAlgoFromApi = find(_algos, a => ['ocl-bridge', 'ocl-ciel-bridge'].includes(a.type))
+        if(bridgeAlgoFromApi) {
+          const bridgeUrl = bridgeAlgoFromApi.target_repo_url || '/orgs/CIEL/sources/CIEL/'
+          fetchMappedSources(bridgeUrl + 'latest/', sources =>
+            setBridgeMappedSources(prev => ({...prev, [bridgeUrl]: sources})))
+        }
       } catch {
         // pass
       }
@@ -1224,7 +1229,7 @@ const MapProject = () => {
       forEach(_selectedAlgos, algo => {
         if(['custom', 'ocl-search', 'ocl-semantic'].includes(algo.type))
           algoPromises.push(processWithConcurrency(repo, algo, rowsToProcess));
-        else if(algo.type === 'ocl-ciel-bridge' && canBridge)
+        else if(['ocl-bridge', 'ocl-ciel-bridge'].includes(algo.type) && canBridge)
           algoPromises.push(fetchBulkBridgeCandidates(rowsToProcess, algo))
         else if(algo.type === 'ocl-scispacy' && canScispacy)
           algoPromises.push(fetchBulkScispacyCandidates(rowsToProcess, algo))
@@ -1485,7 +1490,7 @@ const MapProject = () => {
   const getBulkBridgeCandidatesButtonLabel = () => {
     const effectiveEnd = loadingMatches ? _now : bridgeCandidatesEndedAt;
     const matchingDuration = getMatchingDuration(bridgeCandidatesStartedAt, effectiveEnd)
-    if(loadingMatches || allCandidatesRef.current['ocl-ciel-bridge']?.length)
+    if(loadingMatches || Object.keys(allCandidatesRef.current).some(k => k.includes('bridge') && allCandidatesRef.current[k]?.length))
       return `${t('map_project.bridge_candidates')} (${matchingDuration})`
     return t('map_project.bridge_candidates')
   }
@@ -1704,7 +1709,7 @@ const MapProject = () => {
       __candidates = times(CANDIDATES_LIMIT, i => __candidates[i])
       forEach(__candidates, (candidate, i) => {
         if(candidate?.id) {
-          const isBridge = algoId === 'ocl-ciel-bridge'
+          const isBridge = algoId.includes('bridge')
           candidates[`__result_${algoKey}_${twoDigit(i + 1)}__`] = candidate?.id ?
             (
               isBridge ?
@@ -2135,7 +2140,7 @@ const MapProject = () => {
         fetchOCLOrCustomCandidates(algoDef, _row, offset, _retired, _filters, onResponse)
       } else if (algoDef.type === 'ocl-scispacy') {
         fetchScispacyCandidates(__row, scrollToBottom, forceReload, false, onResponse)
-      } else if (algoDef.type === 'ocl-ciel-bridge') {
+      } else if (['ocl-bridge', 'ocl-ciel-bridge'].includes(algoDef.type)) {
         fetchBridgeCandidates(__row, offset, _retired, scrollToBottom, _filters, forceReload, false, onResponse)
       }
     } else {
@@ -2265,7 +2270,8 @@ const MapProject = () => {
 
   const fetchBridgeCandidates = (_row, offset=0, _retired, scrollToBottom, _filters, forceReload=false, isBulk=false, callback) => {
     let __row = isEmpty(_row) ? row : _row
-    const existingCandidates = find(allCandidatesRef.current['ocl-ciel-bridge'], c => c.row.__index === __row.__index)?.results
+    const bridgeAlgoId = bridgeAlgo?.id || 'ocl-ciel-bridge'
+    const existingCandidates = find(allCandidatesRef.current[bridgeAlgoId], c => c.row.__index === __row.__index)?.results
     if(!isBulk && !forceReload && offset === 0 && !_retired && existingCandidates?.length> 0) {
       setTimeout(() => highlightTexts(existingCandidates, null, false), 100)
       return
@@ -2284,8 +2290,8 @@ const MapProject = () => {
           callback(candidates, payload)
       },
       (response, errorMsg) => {
-        markAlgo(__row.__index, 'ocl-ciel-bridge', -2)
-        log({action: 'algo_failed', extras: {algo: 'ocl-ciel-bridge'}}, __row.__index)
+        markAlgo(__row.__index, bridgeAlgoId, -2)
+        log({action: 'algo_failed', extras: {algo: bridgeAlgoId}}, __row.__index)
         setAlert({message: response?.detail || errorMsg, severity: 'error'})
         setIsLoadingInDecisionView(false)
       }
@@ -2296,7 +2302,7 @@ const MapProject = () => {
     const algo = algoId ? getAlgoDef(algoId) : null
     if(algo?.lookup_required && (lookupConfig?.url || repoVersion.url) && candidates && isArray(candidates) && candidates.length) {
       candidates.forEach(concept => {
-        if(algo.type === 'ocl-ciel-bridge') {
+        if(['ocl-bridge', 'ocl-ciel-bridge'].includes(algo.type)) {
           forEach(concept.mappings, mapping => {
             lookupCode(mapping.cascade_target_concept_code)
           })
@@ -2624,6 +2630,7 @@ const MapProject = () => {
       isLoadingLocales={isLoadingLocales}
       bridgeEnabled={bridgeEnabled}
       canBridge={canBridge}
+      isCoreUser={isCoreUser}
       canScispacy={canScispacy}
       scispacyEnabled={scispacyEnabled}
       setAIAssistantColumns={setAIAssistantColumns}
@@ -2637,16 +2644,20 @@ const MapProject = () => {
   return permissionDenied ? <Error403/> : (
     <div className='col-xs-12 padding-0' style={{borderRadius: '10px', width: 'calc(100vw - 32px)'}}>
       {
-        Boolean(repoVersion?.url) && CIELMappedSources.length > 0 &&
-          <BridgeMatch
-            service={getMatchAPIService()}
-            repo={repoVersion}
-            bridgeRepoURL='/orgs/CIEL/sources/CIEL/'
-            limit={CANDIDATES_LIMIT}
-            user={user}
-            ref={bridgeRef}
-            mappedRepoURLs={CIELMappedSources.map(source => source.url)}
-          />
+        (() => {
+          const bridgeUrl = bridgeAlgo?.target_repo_url || '/orgs/CIEL/sources/CIEL/'
+          const mappedSrcs = bridgeMappedSources[bridgeUrl] || []
+          return Boolean(repoVersion?.url) && mappedSrcs.length > 0 &&
+            <BridgeMatch
+              service={getMatchAPIService()}
+              repo={repoVersion}
+              bridgeRepoURL={bridgeUrl}
+              limit={CANDIDATES_LIMIT}
+              user={user}
+              ref={bridgeRef}
+              mappedRepoURLs={mappedSrcs.map(source => source.url)}
+            />
+        })()
       }
       {
         loadingProject &&

--- a/src/components/map-projects/MultiAlgoSelector.jsx
+++ b/src/components/map-projects/MultiAlgoSelector.jsx
@@ -74,7 +74,8 @@ export default function MultiAlgoSelector({
   value,
   onChange,
   maxAlgos=5,
-  repo
+  repo,
+  isCoreUser
 }) {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(() => new Map());
@@ -213,7 +214,7 @@ export default function MultiAlgoSelector({
       return <MatchingIcon sx={{fontSize: '1.5rem', color: 'primary.main'}} />
     if(algo.type === 'ocl-semantic' && algo.provider === 'ocl')
       return <MatchingIcon sx={{fontSize: '1.5rem', color: 'primary.main'}} />
-    if(algo.type === 'ocl-ciel-bridge' && algo.provider === 'ocl')
+    if(algo.type?.includes('bridge') && algo.provider === 'ocl')
       return <i className="fa-solid fa-bridge" style={{fontSize: '1.5rem', color: 'primary.main'}} />
     if(algo.type === 'ocl-scispacy' && algo.provider === 'ocl')
       return <img src="https://allenai.github.io/scispacy/scispacy-logo-square.png" style={{objectFit: 'cover', width: '28px', height: '28px'}} />
@@ -503,6 +504,39 @@ export default function MultiAlgoSelector({
                           </Stack>
                         </Stack>
                       </Paper>
+                    ) : algo.type?.includes('bridge') ? (
+                      <Stack spacing={1.5}>
+                        {isCoreUser && (
+                          <TextField
+                            fullWidth
+                            label={t('map_project.bridge_source_url') || 'Bridge Source URL'}
+                            value={sel.target_repo_url ?? algo.target_repo_url ?? '/orgs/CIEL/sources/CIEL/'}
+                            onChange={(e) => updateSelected(sel.__key, { target_repo_url: e.target.value })}
+                            placeholder="/orgs/CIEL/sources/CIEL/"
+                            helperText={t('map_project.bridge_source_url_description') || 'The interface terminology to search through for bridge matching'}
+                          />
+                        )}
+                        <Stack direction={{ xs: "column", sm: "row" }} spacing={1.5}>
+                          <TextField
+                            label={t('map_project.batch_size')}
+                            sx={{width: '50%'}}
+                            type="number"
+                            value={sel.batch_size ?? algo.batch_size ?? 10}
+                            onChange={(e) => updateSelected(sel.__key, { batch_size: clampInt(e.target.value, 1, 1000) })}
+                          />
+                          <TextField
+                            label={t('map_project.concurrent_requests')}
+                            sx={{width: '50%'}}
+                            type="number"
+                            value={sel.concurrent_requests ?? algo.concurrent_requests ?? 1}
+                            onChange={(e) =>
+                              updateSelected(sel.__key, {
+                                concurrent_requests: clampInt(e.target.value, 1, 50),
+                              })
+                            }
+                          />
+                        </Stack>
+                      </Stack>
                     ) : (
                       <Stack direction={{ xs: "column", sm: "row" }} spacing={1.5}>
                         <TextField


### PR DESCRIPTION
## Summary
- Parameterizes bridge matching to support custom bridge sources beyond CIEL
- Replaces hardcoded CIEL URLs with dynamic `target_repo_url` from algo config (defaults to CIEL)
- Adds "Bridge Source URL" text field in algorithm settings panel, visible only to `core_user` group members
- Accepts both `ocl-bridge` and `ocl-ciel-bridge` algo types for backward compatibility
- All 5 files with CIEL-specific references updated

### Files changed
- **MapProject.jsx** — State, bridge detection, mapped sources fetch, BridgeMatch props, ~10 string refs
- **MultiAlgoSelector.jsx** — Bridge icon detection, bridge source URL field (core_user gated)
- **Concept.jsx** — Bridge algo detection
- **Candidates.jsx** — Bridge flag for candidate display
- **ConfigurationForm.jsx** — Bridge algo type check, isCoreUser prop threading

### Related PRs
- OpenConceptLab/oclapi2#851 (API label change)
- OpenConceptLab/react-bridge-match#1 (guard removal)

Part of OpenConceptLab/ocl_issues#2471

## Test plan
- [ ] Existing CIEL bridge projects work unchanged
- [ ] Core user can expand bridge algo settings and see Bridge Source URL field
- [ ] Non-core user does NOT see Bridge Source URL field
- [ ] Entering a custom bridge source URL and running auto-match returns bridge-formatted results
- [ ] Multi-algo eval (bridge + semantic) reranks and exports correctly
- [ ] Bridge results display with cascade mapping chain visualization

🤖 Generated with [Claude Code](https://claude.com/claude-code)