### PR TITLE
Unified mapper data model PR1: normalizers + parallel state

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "scripts": {
     "start": "./node_modules/webpack-dev-server/bin/webpack-dev-server.js --progress --host 0.0.0.0 --port ${WEB_PORT} --env API_URL=${API_URL} --env NODE_ENV=${NODE_ENV} --env RECAPTCHA_SITE_KEY=${RECAPTCHA_SITE_KEY} --env GA_ACCOUNT_ID=${GA_ACCOUNT_ID} --env HOTJAR_ID=${HOTJAR_ID} --env ERRBIT_URL=${ERRBIT_URL} --env ERRBIT_KEY=${ERRBIT_KEY} --env LOGIN_REDIRECT_URL=${LOGIN_REDIRECT_URL} --env OIDC_RP_CLIENT_ID=${OIDC_RP_CLIENT_ID} --env OIDC_RP_CLIENT_SECRET=${OIDC_RP_CLIENT_SECRET} --env OCL_ONLINE=${OCL_ONLINE} --env BRIDGE_MATCH_URL=${BRIDGE_MATCH_URL} --env AI_ASSISTANT_API_URL=${AI_ASSISTANT_API_URL} --env SCISPACY_LOINC_API_URL=${SCISPACY_LOINC_API_URL} --env OCL_ONLINE_API_URL=${OCL_ONLINE_API_URL} --mode ${NODE_ENV} --hot",
     "build": "node --max-old-space-size=1536 ./node_modules/webpack/bin/webpack.js --progress --env API_URL=${API_URL} --env NODE_ENV=${NODE_ENV} --env RECAPTCHA_SITE_KEY=${RECAPTCHA_SITE_KEY} --env GA_ACCOUNT_ID=${GA_ACCOUNT_ID} --env HOTJAR_ID=${HOTJAR_ID} --env ERRBIT_URL=${ERRBIT_URL} --env ERRBIT_KEY=${ERRBIT_KEY} --env LOGIN_REDIRECT_URL=${LOGIN_REDIRECT_URL} --env OIDC_RP_CLIENT_ID=${OIDC_RP_CLIENT_ID} --env OIDC_RP_CLIENT_SECRET=${OIDC_RP_CLIENT_SECRET} --env OCL_ONLINE=${OCL_ONLINE} --env BRIDGE_MATCH_URL=${BRIDGE_MATCH_URL} --env AI_ASSISTANT_API_URL=${AI_ASSISTANT_API_URL} --env SCISPACY_LOINC_API_URL=${SCISPACY_LOINC_API_URL} --env OCL_ONLINE_API_URL=${OCL_ONLINE_API_URL} --mode ${NODE_ENV}",
-    "eslint": "./node_modules/.bin/eslint ./src"
+    "eslint": "./node_modules/.bin/eslint ./src",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test 'src/**/__tests__/**/*.test.js'"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",

--- a/src/components/map-projects/MapProject.jsx
+++ b/src/components/map-projects/MapProject.jsx
@@ -288,13 +288,13 @@ const MapProject = () => {
       concept_rows: { ...prevRow.concept_rows },
     }
 
-    for(const cr of concept_rows) {
+    concept_rows.forEach(cr => {
       const existing = nextRow.concept_rows[cr.concept_url]
       // Preserve any existing rerank_score; otherwise take the new entry.
       nextRow.concept_rows[cr.concept_url] = existing && existing.rerank_score !== undefined
         ? existing
         : cr
-    }
+    })
 
     rowMatchStateRef.current = { ...prevAll, [rowIndex]: nextRow }
     setRowMatchState(rowMatchStateRef.current)
@@ -303,15 +303,35 @@ const MapProject = () => {
     // richer (lookup_status='full') over stubs ('pending'/'partial').
     setConceptCache(prev => {
       const next = { ...prev }
-      for(const def of concept_definitions) {
+      concept_definitions.forEach(def => {
         const existing = next[def.url]
         if(!existing || lookupStatusRank(def.lookup_status) > lookupStatusRank(existing.lookup_status)) {
           next[def.url] = def
         }
-      }
+      })
       return next
     })
   }, [])
+
+  // Build projectContext for the unified-model normalizer.
+  // Target repo canonical URL is read from repo metadata; if absent, derive
+  // 'https://ns.openconceptlab.org' + relative URL (per OCL canonical
+  // conventions — see plans/unified-mapper-model.md).
+  const buildProjectContext = React.useCallback(() => {
+    if(!repo?.url) return null
+    const targetCanonical = repo.canonical_url || `https://ns.openconceptlab.org${repo.url}`
+    return {
+      namespace: get(project, 'owner_url') || owner,
+      target_repo: {
+        relative_url: repo.url,
+        canonical_url: targetCanonical,
+        canonical_url_source: repo.canonical_url ? 'repo' : 'derived',
+        version: repoVersion?.id || repo.version
+      }
+      // bridge_repo is set per-invocation when the algo is a bridge algo
+      // (bridge path doesn't flow through this onResponse handler in PR 1).
+    }
+  }, [project, owner, repo, repoVersion])
 
   const allCandidatesRef = React.useRef({})
 
@@ -2210,27 +2230,8 @@ const MapProject = () => {
       }
       markAlgo(__row.__index, algoId, 0)
       setIsLoadingInDecisionView(true)
-      // Build projectContext for the unified-model normalizer.
-      // Target repo canonical URL is read from repo metadata; if absent, derive
-      // 'https://ns.openconceptlab.org' + relative URL (per OCL canonical
-      // conventions — see plans/unified-mapper-model.md).
-      const buildProjectContext = () => {
-        if(!repo?.url) return null
-        const targetCanonical = repo.canonical_url || `https://ns.openconceptlab.org${repo.url}`
-        return {
-          namespace: get(project, 'owner_url') || owner,
-          target_repo: {
-            relative_url: repo.url,
-            canonical_url: targetCanonical,
-            canonical_url_source: repo.canonical_url ? 'repo' : 'derived',
-            version: repoVersion?.id || repo.version
-          }
-          // bridge_repo is set per-invocation when the algo is a bridge algo
-          // (bridge path doesn't flow through this onResponse handler in PR 1).
-        }
-      }
-
       const onResponse = (response, payload) => {
+        const projectContext = UNIFIED_MODEL_ENABLED ? buildProjectContext() : null
         if(response?.detail) {
           markAlgo(__row.__index, algoId, -2)
           log({action: 'algo_failed', extras: {algo: algoId}}, __row.__index)
@@ -2239,7 +2240,7 @@ const MapProject = () => {
             mergeIntoRowMatchState(__row.__index, normalizeAlgorithmInvocation(null, {
               algorithmId: algoId,
               algorithmConfig: algoDef,
-              projectContext: buildProjectContext(),
+              projectContext,
               rowIndex: __row.__index,
               status: 'failed',
               error: response.detail,
@@ -2264,7 +2265,7 @@ const MapProject = () => {
               mergeIntoRowMatchState(__row.__index, normalizeAlgorithmInvocation(rowPayload, {
                 algorithmId: algoId,
                 algorithmConfig: algoDef,
-                projectContext: buildProjectContext(),
+                projectContext,
                 rowIndex: __row.__index,
                 rawResponse: response
               }))

--- a/src/components/map-projects/MapProject.jsx
+++ b/src/components/map-projects/MapProject.jsx
@@ -104,9 +104,21 @@ import ProjectLogs from './ProjectLogs';
 import { useAlgos } from './algorithms'
 import AutoMatchDialog from './AutoMatchDialog'
 import { DEFAULT_ENCODER_MODEL } from './rerankerModels'
+import { normalizeAlgorithmInvocation, lookupStatusRank } from './normalizers'
 
 import './MapProject.scss'
 import '../common/ResizablePanel.scss'
+
+/**
+ * Feature flag for the unified candidate/concept data model
+ * (plans/unified-mapper-model.md, ocl_issues#2337). When OFF (default), this
+ * file behaves exactly as before. When ON, algorithm responses are *also*
+ * normalized into the new RowMatchState shape (in parallel with the legacy
+ * allCandidates state). PR 2 will flip reads to consume the new state and
+ * remove the legacy path. PR 1 deliberately keeps reads on the legacy state
+ * so behavior is unchanged.
+ */
+const UNIFIED_MODEL_ENABLED = false
 
 // const LOG = {
 //   action: '',
@@ -147,6 +159,17 @@ const MapProject = () => {
 
   // Algo Candidates
   const [allCandidates, setAllCandidates] = React.useState({}); // ocl-scispacy-loinc
+
+  // Unified candidate/concept model (plans/unified-mapper-model.md). Populated
+  // in parallel with allCandidates when UNIFIED_MODEL_ENABLED is true. Shape:
+  //   { [rowIndex]: {
+  //       algorithm_responses: { [id]: AlgorithmResponse },
+  //       candidates:          { [id]: Candidate },
+  //       concept_rows:        { [concept_url]: ConceptRow },
+  //   } }
+  // ConceptDefinitions live in the project-wide conceptCache (already URL-keyed).
+  const [, setRowMatchState] = React.useState({})
+  const rowMatchStateRef = React.useRef({})
 
   const [searchedConcepts, setSearchedConcepts] = React.useState({});
   const [fetchedFacets, setFetchedFacets] = React.useState({});
@@ -235,6 +258,60 @@ const MapProject = () => {
     rowStageRef.current = next;
     _setRowStage(next);
   }, []);
+
+  /**
+   * Merge a normalized invocation into the row's RowMatchState (in-place on
+   * the ref, then setState to trigger renders once read paths are flipped).
+   * Concept definitions are merged into conceptCache (project-wide). Concept
+   * rows are merged per-row, preferring existing rerank_score over undefined.
+   */
+  const mergeIntoRowMatchState = React.useCallback((rowIndex, normalized) => {
+    if(!normalized) return
+    const { algorithm_response, candidates, concept_definitions, concept_rows } = normalized
+
+    const prevAll = rowMatchStateRef.current
+    const prevRow = prevAll[rowIndex] || {
+      algorithm_responses: {},
+      candidates: {},
+      concept_rows: {},
+    }
+
+    const nextRow = {
+      algorithm_responses: {
+        ...prevRow.algorithm_responses,
+        [algorithm_response.id]: algorithm_response,
+      },
+      candidates: {
+        ...prevRow.candidates,
+        ...candidates.reduce((acc, c) => { acc[c.id] = c; return acc }, {}),
+      },
+      concept_rows: { ...prevRow.concept_rows },
+    }
+
+    for(const cr of concept_rows) {
+      const existing = nextRow.concept_rows[cr.concept_url]
+      // Preserve any existing rerank_score; otherwise take the new entry.
+      nextRow.concept_rows[cr.concept_url] = existing && existing.rerank_score !== undefined
+        ? existing
+        : cr
+    }
+
+    rowMatchStateRef.current = { ...prevAll, [rowIndex]: nextRow }
+    setRowMatchState(rowMatchStateRef.current)
+
+    // Merge ConceptDefinitions into the project-wide conceptCache. Prefer
+    // richer (lookup_status='full') over stubs ('pending'/'partial').
+    setConceptCache(prev => {
+      const next = { ...prev }
+      for(const def of concept_definitions) {
+        const existing = next[def.url]
+        if(!existing || lookupStatusRank(def.lookup_status) > lookupStatusRank(existing.lookup_status)) {
+          next[def.url] = def
+        }
+      }
+      return next
+    })
+  }, [])
 
   const allCandidatesRef = React.useRef({})
 
@@ -2133,11 +2210,42 @@ const MapProject = () => {
       }
       markAlgo(__row.__index, algoId, 0)
       setIsLoadingInDecisionView(true)
+      // Build projectContext for the unified-model normalizer.
+      // Target repo canonical URL is read from repo metadata; if absent, derive
+      // 'https://ns.openconceptlab.org' + relative URL (per OCL canonical
+      // conventions — see plans/unified-mapper-model.md).
+      const buildProjectContext = () => {
+        if(!repo?.url) return null
+        const targetCanonical = repo.canonical_url || `https://ns.openconceptlab.org${repo.url}`
+        return {
+          namespace: get(project, 'owner_url') || owner,
+          target_repo: {
+            relative_url: repo.url,
+            canonical_url: targetCanonical,
+            canonical_url_source: repo.canonical_url ? 'repo' : 'derived',
+            version: repoVersion?.id || repo.version
+          }
+          // bridge_repo is set per-invocation when the algo is a bridge algo
+          // (bridge path doesn't flow through this onResponse handler in PR 1).
+        }
+      }
+
       const onResponse = (response, payload) => {
         if(response?.detail) {
           markAlgo(__row.__index, algoId, -2)
           log({action: 'algo_failed', extras: {algo: algoId}}, __row.__index)
           setAlert({message: response.detail, severity: 'error'})
+          if(UNIFIED_MODEL_ENABLED) {
+            mergeIntoRowMatchState(__row.__index, normalizeAlgorithmInvocation(null, {
+              algorithmId: algoId,
+              algorithmConfig: algoDef,
+              projectContext: buildProjectContext(),
+              rowIndex: __row.__index,
+              status: 'failed',
+              error: response.detail,
+              rawResponse: response
+            }))
+          }
           return
         }
         log({action: 'algo_finished', extras: {algo: algoId}}, __row.__index)
@@ -2147,12 +2255,28 @@ const MapProject = () => {
           const results = algoId === 'ocl-scispacy-loinc' ? [{row: __row, results: fromScispacyResultsToConcepts(get(response.data, __row.__index) || [])}] : data
           nextCandidates = {...allCandidatesRef.current, [algoId]: [...reject(allCandidatesRef.current[algoId], c => c.row.__index === __row.__index), ...(results || [])]}
           lookupCandidates(algoId, get(results, '0.results'))
+          if(UNIFIED_MODEL_ENABLED) {
+            // Normalize the invocation for this row and merge into the new
+            // RowMatchState. Reads still come from allCandidates — flipping
+            // reads is PR 2.
+            const rowPayload = find(results, r => r?.row?.__index === __row.__index)
+            if(rowPayload) {
+              mergeIntoRowMatchState(__row.__index, normalizeAlgorithmInvocation(rowPayload, {
+                algorithmId: algoId,
+                algorithmConfig: algoDef,
+                projectContext: buildProjectContext(),
+                rowIndex: __row.__index,
+                rawResponse: response
+              }))
+            }
+          }
         } else {
           const newMatches = [...(allCandidatesRef.current[algoId] || [])]
           const index = findIndex(newMatches, match => match.row.__index === __row.__index)
           newMatches[index].results = [...newMatches[index].results, ...(get(data, '0.results') || [])]
           lookupCandidates(algoId, get(data, '0.results'))
           nextCandidates = {...allCandidatesRef.current, [algoId]: newMatches}
+          // TODO(unified-model): pagination append path. PR 2 work.
         }
         allCandidatesRef.current = nextCandidates
         setAllCandidates(nextCandidates)

--- a/src/components/map-projects/__tests__/normalizers.test.js
+++ b/src/components/map-projects/__tests__/normalizers.test.js
@@ -1,0 +1,600 @@
+/**
+ * Unit tests for the normalizers module.
+ *
+ * Run with: npm test
+ *
+ * Fixtures here are synthesized from the response shapes documented in
+ * plans/unified-mapper-model.md and observed in MapProject.jsx
+ * (fromScispacyResultsToConcepts at line 2315; bridge handling at 1083-1097;
+ * search_meta usage at Score.jsx:18-46).
+ *
+ * They should be replaced/refined against captured real responses during the
+ * verification pass — see plans/unified-mapper-model.md "Verification Plan".
+ */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  createAlgorithmResponse,
+  normalizeAlgoResult,
+  normalizeAlgorithmInvocation
+} from '../normalizers.js'
+import { makeConceptKey, parseConceptKey, referencesEqual } from '../conceptKey.js'
+
+// ---------- Project context (shared across tests) ----------
+
+const projectContext = {
+  namespace: '/orgs/MyOrg/',
+  target_repo: {
+    relative_url: '/orgs/Regenstrief/sources/LOINC/',
+    canonical_url: 'http://loinc.org',
+    canonical_url_source: 'repo'
+  },
+  bridge_repo: {
+    relative_url: '/orgs/CIEL/sources/CIEL/',
+    canonical_url: 'https://CIELterminology.org',
+    canonical_url_source: 'repo'
+  }
+}
+
+// ---------- Algorithm configs (would live in algorithms.jsx) ----------
+
+const oclSearchAlgo = {
+  id: 'ocl-search',
+  type: 'ocl-search',
+  concept_identity: {
+    reference_source: 'target_repo',
+    code_field: 'id',
+    ocl_url_field: 'url'
+  }
+}
+
+const oclSemanticAlgo = {
+  id: 'ocl-semantic',
+  type: 'ocl-semantic',
+  concept_identity: {
+    reference_source: 'target_repo',
+    code_field: 'id',
+    ocl_url_field: 'url'
+  }
+}
+
+const oclScispacyAlgo = {
+  id: 'ocl-scispacy-loinc',
+  type: 'ocl-scispacy',
+  concept_identity: {
+    reference_source: 'fixed',
+    canonical_url: 'http://loinc.org',
+    code_field: 'id'
+    // no ocl_url_field — scispacy responses don't include it
+  }
+}
+
+const oclBridgeAlgo = {
+  id: 'ocl-bridge',
+  type: 'ocl-bridge',
+  concept_identity: {
+    reference_source: 'bridge_repo',
+    code_field: 'id',
+    ocl_url_field: 'url',
+    cascade_target: {
+      reference_source: 'target_repo',
+      code_field: 'cascade_target_concept_code',
+      ocl_url_field: 'cascade_target_concept_url'
+    }
+  }
+}
+
+// ---------- Fixtures ----------
+
+const oclSearchResult_LOINC_glucose_full = {
+  id: '49494-3',
+  display_name: 'Glucose [Mass/volume] in Blood',
+  url: '/orgs/Regenstrief/sources/LOINC/concepts/49494-3/',
+  source: 'LOINC',
+  owner: 'Regenstrief',
+  names: [
+    { name: 'Glucose [Mass/volume] in Blood', locale: 'en', preferred: true }
+  ],
+  descriptions: [
+    { description: 'Glucose mass per volume in blood', locale: 'en' }
+  ],
+  concept_class: 'LOINC',
+  datatype: 'Numeric',
+  retired: false,
+  search_meta: {
+    search_score: 0.85,
+    search_normalized_score: 85,
+    search_highlight: { name: ['<em>Glucose</em>'] },
+    algorithm: 'ocl-search'
+  }
+}
+
+const oclSemanticResult_LOINC_glucose_full = {
+  ...oclSearchResult_LOINC_glucose_full,
+  search_meta: {
+    search_score: 0.91,
+    search_normalized_score: 91,
+    search_highlight: { synonyms: ['Glucose'] },
+    algorithm: 'ocl-semantic'
+  }
+}
+
+// scispacy results (post fromScispacyResultsToConcepts) — partial, NO url field
+const scispacyResult_partial = {
+  id: '49494-3',
+  display_name: 'Glucose [Mass/volume] in Blood',
+  source: 'LOINC',
+  search_meta: {
+    search_score: 0.78,
+    search_normalized_score: 78,
+    algorithm: 'ocl-scispacy-loinc'
+  },
+  extras: { LOINC_NUM: '49494-3', composite_score: 0.78 }
+}
+
+const bridgeResult_CIEL_to_LOINC = {
+  id: 'CIEL_12345',
+  display_name: 'Blood glucose measurement',
+  url: '/orgs/CIEL/sources/CIEL/concepts/CIEL_12345/',
+  source: 'CIEL',
+  owner: 'CIEL',
+  names: [{ name: 'Blood glucose measurement', locale: 'en', preferred: true }],
+  search_meta: {
+    search_score: 0.92,
+    search_normalized_score: 92,
+    search_highlight: { name: ['<em>blood glucose</em>'] },
+    algorithm: 'ocl-bridge'
+  },
+  mappings: [
+    {
+      cascade_target_concept_code: '49494-3',
+      cascade_target_concept_url: '/orgs/Regenstrief/sources/LOINC/concepts/49494-3/',
+      cascade_target_concept_name: 'Glucose [Mass/volume] in Blood',
+      cascade_target_source_name: 'LOINC',
+      map_type: 'SAME-AS'
+    }
+  ]
+}
+
+const bridgeResult_multiTarget = {
+  id: 'CIEL_99999',
+  display_name: 'Hypertension',
+  url: '/orgs/CIEL/sources/CIEL/concepts/CIEL_99999/',
+  source: 'CIEL',
+  owner: 'CIEL',
+  search_meta: { search_score: 0.88, algorithm: 'ocl-bridge' },
+  mappings: [
+    {
+      cascade_target_concept_code: 'I10',
+      cascade_target_concept_url: '/orgs/WHO/sources/ICD-10/concepts/I10/',
+      cascade_target_concept_name: 'Essential hypertension',
+      cascade_target_source_name: 'ICD-10',
+      map_type: 'SAME-AS'
+    },
+    {
+      cascade_target_concept_code: '38341003',
+      cascade_target_concept_url: '/orgs/IHTSDO/sources/SNOMED-CT/concepts/38341003/',
+      cascade_target_concept_name: 'Hypertensive disorder',
+      cascade_target_source_name: 'SNOMED-CT',
+      map_type: 'NARROWER-THAN'
+    }
+  ]
+}
+
+// ---------- conceptKey helpers ----------
+
+test('makeConceptKey + parseConceptKey roundtrip without version', () => {
+  const ref = { url: 'http://loinc.org', code: '49494-3' }
+  const key = makeConceptKey(ref)
+  const back = parseConceptKey(key)
+  assert.deepEqual(back, ref)
+})
+
+test('makeConceptKey + parseConceptKey roundtrip with version', () => {
+  const ref = { url: 'http://loinc.org', code: '49494-3', version: '2.74' }
+  const key = makeConceptKey(ref)
+  const back = parseConceptKey(key)
+  assert.deepEqual(back, ref)
+})
+
+test('makeConceptKey throws on missing url or code', () => {
+  assert.throws(() => makeConceptKey({ url: 'x' }), TypeError)
+  assert.throws(() => makeConceptKey({ code: 'x' }), TypeError)
+  assert.throws(() => makeConceptKey(null), TypeError)
+})
+
+test('referencesEqual ignores undefined-vs-null version', () => {
+  const a = { url: 'http://loinc.org', code: '49494-3' }
+  const b = { url: 'http://loinc.org', code: '49494-3', version: undefined }
+  assert.equal(referencesEqual(a, b), true)
+})
+
+test('two references with the same url+code produce the same key', () => {
+  const a = { url: 'http://loinc.org', code: '49494-3' }
+  const b = { url: 'http://loinc.org', code: '49494-3' }
+  assert.equal(makeConceptKey(a), makeConceptKey(b))
+})
+
+// ---------- createAlgorithmResponse ----------
+
+test('createAlgorithmResponse preserves raw response and stamps metadata', () => {
+  const raw = { foo: 'bar' }
+  const response = createAlgorithmResponse(raw, 'ocl-search', { rowIndex: 3 })
+
+  assert.equal(response.algorithm_id, 'ocl-search')
+  assert.equal(response.row_index, 3)
+  assert.equal(response.status, 'success')
+  assert.equal(response.raw, raw, 'raw should be preserved by reference')
+  assert.match(response.id, /.+/)
+  assert.match(response.received_at, /^\d{4}-\d{2}-\d{2}T/)
+  assert.equal(response.error, undefined)
+})
+
+test('createAlgorithmResponse records error when status=failed', () => {
+  const response = createAlgorithmResponse(null, 'ocl-bridge', {
+    status: 'failed',
+    error: 'Network timeout'
+  })
+
+  assert.equal(response.status, 'failed')
+  assert.equal(response.error, 'Network timeout')
+})
+
+// ---------- normalizeAlgoResult: standard ----------
+
+test('standard result produces 1 candidate + 1 ConceptDefinition + 1 ConceptRow', () => {
+  const out = normalizeAlgoResult(oclSearchResult_LOINC_glucose_full, {
+    algorithmId: 'ocl-search',
+    algorithmConfig: oclSearchAlgo,
+    algorithmResponseId: 'ar-1',
+    projectContext
+  })
+
+  assert.equal(out.candidates.length, 1)
+  assert.equal(out.concept_definitions.length, 1)
+  assert.equal(out.concept_rows.length, 1)
+
+  const [cand] = out.candidates
+  assert.equal(cand.type, 'standard')
+  assert.equal(cand.algorithm_id, 'ocl-search')
+  assert.equal(cand.algorithm_response_id, 'ar-1')
+  assert.equal(cand.score, 0.85)
+  assert.deepEqual(cand.highlights, { name: ['<em>Glucose</em>'] })
+  assert.equal(cand.bridge_concept_key, undefined)
+  assert.equal(cand.parent_candidate_id, undefined)
+})
+
+test('standard ConceptDefinition has reference {url, code} from target_repo', () => {
+  const out = normalizeAlgoResult(oclSearchResult_LOINC_glucose_full, {
+    algorithmId: 'ocl-search',
+    algorithmConfig: oclSearchAlgo,
+    algorithmResponseId: 'ar-1',
+    projectContext
+  })
+  const [def] = out.concept_definitions
+
+  assert.deepEqual(def.reference, { url: 'http://loinc.org', code: '49494-3' })
+  assert.equal(def.key, makeConceptKey(def.reference))
+  assert.equal(def.ocl_url, '/orgs/Regenstrief/sources/LOINC/concepts/49494-3/')
+  assert.equal(def.lookup_status, 'full')
+  assert.equal(def.lookup_source_type, 'algorithm')
+  assert.equal(def.lookup_source, 'ocl-search')
+  assert.equal(def.display_name, 'Glucose [Mass/volume] in Blood')
+})
+
+test('Candidate.concept_key matches ConceptDefinition.key', () => {
+  const out = normalizeAlgoResult(oclSearchResult_LOINC_glucose_full, {
+    algorithmId: 'ocl-search',
+    algorithmConfig: oclSearchAlgo,
+    algorithmResponseId: 'ar-1',
+    projectContext
+  })
+  assert.equal(out.candidates[0].concept_key, out.concept_definitions[0].key)
+})
+
+test('ConceptRow is created with rerank_score=undefined for the matched concept', () => {
+  const out = normalizeAlgoResult(oclSearchResult_LOINC_glucose_full, {
+    algorithmId: 'ocl-search',
+    algorithmConfig: oclSearchAlgo,
+    algorithmResponseId: 'ar-1',
+    projectContext
+  })
+  const [row] = out.concept_rows
+  assert.equal(row.concept_key, out.concept_definitions[0].key)
+  assert.equal(row.rerank_score, undefined)
+})
+
+// ---------- normalizeAlgoResult: scispacy (no url, no ocl_url) ----------
+
+test('scispacy result with fixed canonical produces a partial ConceptDefinition with no ocl_url', () => {
+  const out = normalizeAlgoResult(scispacyResult_partial, {
+    algorithmId: 'ocl-scispacy-loinc',
+    algorithmConfig: oclScispacyAlgo,
+    algorithmResponseId: 'ar-2',
+    projectContext
+  })
+
+  assert.equal(out.candidates.length, 1)
+  assert.equal(out.concept_definitions.length, 1)
+
+  const [def] = out.concept_definitions
+  assert.deepEqual(def.reference, { url: 'http://loinc.org', code: '49494-3' })
+  assert.equal(def.ocl_url, undefined,
+    'scispacy has no ocl_url field — must remain undefined until ensureLoaded fills it')
+  assert.equal(def.lookup_status, 'partial',
+    'has id+display_name but no names/descriptions => partial')
+  assert.equal(def.lookup_source_type, 'algorithm')
+  assert.equal(def.lookup_source, 'ocl-scispacy-loinc')
+})
+
+test('scispacy result merges with ocl-search result on the same canonical reference', () => {
+  // Same code from both algos → identical reference → identical key → ONE ConceptRow,
+  // TWO Candidates. Demonstrated via two separate invocations into the same row.
+  const a = normalizeAlgorithmInvocation(
+    { row: { __index: 0 }, results: [oclSearchResult_LOINC_glucose_full] },
+    { algorithmId: 'ocl-search', algorithmConfig: oclSearchAlgo, projectContext, rowIndex: 0 }
+  )
+  const b = normalizeAlgorithmInvocation(
+    { row: { __index: 0 }, results: [scispacyResult_partial] },
+    { algorithmId: 'ocl-scispacy-loinc', algorithmConfig: oclScispacyAlgo, projectContext, rowIndex: 0 }
+  )
+
+  assert.equal(a.candidates[0].concept_key, b.candidates[0].concept_key,
+    'same canonical reference => same key, regardless of algorithm')
+})
+
+// ---------- normalizeAlgoResult: missing data ----------
+
+test('result without id (missing code field) returns empty entities', () => {
+  const out = normalizeAlgoResult(
+    { display_name: 'orphan' },
+    { algorithmId: 'ocl-search', algorithmConfig: oclSearchAlgo, algorithmResponseId: 'ar', projectContext }
+  )
+  assert.equal(out.candidates.length, 0)
+  assert.equal(out.concept_definitions.length, 0)
+  assert.equal(out.concept_rows.length, 0)
+})
+
+test('null/undefined result returns empty entities', () => {
+  assert.deepEqual(
+    normalizeAlgoResult(null, { algorithmId: 'x', algorithmConfig: oclSearchAlgo, algorithmResponseId: 'y', projectContext }),
+    { candidates: [], concept_definitions: [], concept_rows: [] }
+  )
+})
+
+test('missing algorithmConfig returns empty entities', () => {
+  const out = normalizeAlgoResult(oclSearchResult_LOINC_glucose_full, {
+    algorithmId: 'ocl-search',
+    algorithmResponseId: 'ar',
+    projectContext
+  })
+  assert.equal(out.candidates.length, 0)
+})
+
+test('reference_source=target_repo with no target_repo in context returns empty', () => {
+  const out = normalizeAlgoResult(oclSearchResult_LOINC_glucose_full, {
+    algorithmId: 'ocl-search',
+    algorithmConfig: oclSearchAlgo,
+    algorithmResponseId: 'ar',
+    projectContext: {} // no target_repo
+  })
+  assert.equal(out.candidates.length, 0,
+    'cannot resolve identity without target_repo canonical_url')
+})
+
+// ---------- normalizeAlgoResult: bridge ----------
+
+test('bridge result produces 1 bridge candidate + N bridge_child candidates', () => {
+  const out = normalizeAlgoResult(bridgeResult_CIEL_to_LOINC, {
+    algorithmId: 'ocl-bridge',
+    algorithmConfig: oclBridgeAlgo,
+    algorithmResponseId: 'ar-3',
+    projectContext
+  })
+
+  assert.equal(out.candidates.length, 2)
+
+  const bridge = out.candidates.find(c => c.type === 'bridge')
+  const child = out.candidates.find(c => c.type === 'bridge_child')
+
+  assert.ok(bridge && child)
+  assert.equal(bridge.score, 0.92)
+  assert.deepEqual(bridge.highlights, { name: ['<em>blood glucose</em>'] })
+
+  assert.equal(child.parent_candidate_id, bridge.id)
+  assert.equal(child.bridge_concept_key, bridge.concept_key)
+  assert.equal(child.map_type, 'SAME-AS')
+  assert.equal(child.score, undefined)
+  assert.equal(child.highlights, undefined)
+})
+
+test('bridge result: bridge concept uses bridge_repo canonical, target uses target_repo canonical', () => {
+  const out = normalizeAlgoResult(bridgeResult_CIEL_to_LOINC, {
+    algorithmId: 'ocl-bridge',
+    algorithmConfig: oclBridgeAlgo,
+    algorithmResponseId: 'ar-3',
+    projectContext
+  })
+
+  assert.equal(out.concept_definitions.length, 2)
+
+  const bridgeDef = out.concept_definitions.find(d => d.reference.code === 'CIEL_12345')
+  const targetDef = out.concept_definitions.find(d => d.reference.code === '49494-3')
+
+  assert.deepEqual(bridgeDef.reference, {
+    url: 'https://CIELterminology.org', code: 'CIEL_12345'
+  })
+  assert.equal(bridgeDef.ocl_url, '/orgs/CIEL/sources/CIEL/concepts/CIEL_12345/')
+  assert.equal(bridgeDef.lookup_source_type, 'algorithm')
+  assert.equal(bridgeDef.lookup_source, 'ocl-bridge')
+
+  assert.deepEqual(targetDef.reference, {
+    url: 'http://loinc.org', code: '49494-3'
+  })
+  assert.equal(targetDef.ocl_url, '/orgs/Regenstrief/sources/LOINC/concepts/49494-3/')
+  assert.equal(targetDef.lookup_status, 'pending',
+    'cascade target is a stub — must be enriched by ensureLoaded')
+})
+
+test('bridge result creates ConceptRows for BOTH intermediary and target', () => {
+  const out = normalizeAlgoResult(bridgeResult_CIEL_to_LOINC, {
+    algorithmId: 'ocl-bridge',
+    algorithmConfig: oclBridgeAlgo,
+    algorithmResponseId: 'ar-3',
+    projectContext
+  })
+
+  assert.equal(out.concept_rows.length, 2)
+  for (const row of out.concept_rows) {
+    assert.equal(row.rerank_score, undefined)
+  }
+})
+
+test('bridge result with multiple cascade targets fans out 1 + N candidates', () => {
+  const out = normalizeAlgoResult(bridgeResult_multiTarget, {
+    algorithmId: 'ocl-bridge',
+    algorithmConfig: oclBridgeAlgo,
+    algorithmResponseId: 'ar-4',
+    projectContext
+  })
+
+  assert.equal(out.candidates.length, 3)
+  assert.equal(out.candidates.filter(c => c.type === 'bridge').length, 1)
+  assert.equal(out.candidates.filter(c => c.type === 'bridge_child').length, 2)
+  assert.equal(out.concept_definitions.length, 3)
+  assert.equal(out.concept_rows.length, 3)
+
+  const bridge = out.candidates.find(c => c.type === 'bridge')
+  for (const child of out.candidates.filter(c => c.type === 'bridge_child')) {
+    assert.equal(child.parent_candidate_id, bridge.id)
+    assert.equal(child.bridge_concept_key, bridge.concept_key)
+  }
+
+  // Note: cascade target canonicals are derived from project target_repo, NOT from the
+  // cascade response's source_name. So both targets here land under the project's
+  // target_repo canonical (http://loinc.org), not under ICD-10/SNOMED-CT canonicals.
+  // Real multi-cascade-target scenarios would have a single target_repo at project setup.
+  for (const def of out.concept_definitions.filter(d => d !== out.concept_definitions[0])) {
+    assert.equal(def.reference.url, 'http://loinc.org')
+  }
+})
+
+// ---------- normalizeAlgorithmInvocation ----------
+
+test('invocation wraps a multi-result payload into one AlgorithmResponse + flat entities', () => {
+  const payload = {
+    row: { __index: 7 },
+    results: [oclSearchResult_LOINC_glucose_full]
+  }
+  const out = normalizeAlgorithmInvocation(payload, {
+    algorithmId: 'ocl-search',
+    algorithmConfig: oclSearchAlgo,
+    projectContext,
+    rowIndex: 7
+  })
+
+  assert.equal(out.algorithm_response.algorithm_id, 'ocl-search')
+  assert.equal(out.algorithm_response.row_index, 7)
+  assert.equal(out.algorithm_response.status, 'success')
+  assert.equal(out.candidates.length, 1)
+  assert.equal(out.candidates[0].algorithm_response_id, out.algorithm_response.id,
+    'candidate must FK to the response wrapper')
+})
+
+test('invocation deduplicates ConceptDefinitions by key within a payload', () => {
+  // Realistic case: two bridge results in one invocation, both cascading to the
+  // same LOINC target. The cascade target should appear once.
+  const bridgeResultB_to_sameLOINC = {
+    id: 'CIEL_88888',
+    display_name: 'Serum glucose',
+    url: '/orgs/CIEL/sources/CIEL/concepts/CIEL_88888/',
+    source: 'CIEL',
+    search_meta: { search_score: 0.81, algorithm: 'ocl-bridge' },
+    mappings: [
+      {
+        cascade_target_concept_code: '49494-3',
+        cascade_target_concept_url: '/orgs/Regenstrief/sources/LOINC/concepts/49494-3/',
+        cascade_target_concept_name: 'Glucose [Mass/volume] in Blood',
+        cascade_target_source_name: 'LOINC',
+        map_type: 'SAME-AS'
+      }
+    ]
+  }
+  const payload = {
+    row: { __index: 0 },
+    results: [bridgeResult_CIEL_to_LOINC, bridgeResultB_to_sameLOINC]
+  }
+  const out = normalizeAlgorithmInvocation(payload, {
+    algorithmId: 'ocl-bridge',
+    algorithmConfig: oclBridgeAlgo,
+    projectContext,
+    rowIndex: 0
+  })
+
+  // 3 distinct keys: 2 bridge concepts (CIEL_12345, CIEL_88888) + 1 shared LOINC target.
+  assert.equal(out.concept_definitions.length, 3)
+  assert.equal(out.concept_rows.length, 3)
+
+  // 4 candidates: 2 bridges + 2 bridge_children (one per cascade)
+  assert.equal(out.candidates.length, 4)
+  assert.equal(out.candidates.filter(c => c.type === 'bridge').length, 2)
+  assert.equal(out.candidates.filter(c => c.type === 'bridge_child').length, 2)
+
+  // Both bridge_children share the same target concept_key
+  const children = out.candidates.filter(c => c.type === 'bridge_child')
+  assert.equal(children[0].concept_key, children[1].concept_key,
+    'both cascades to the same target should produce candidates with the same concept_key')
+})
+
+test('invocation with empty results still produces an AlgorithmResponse', () => {
+  const out = normalizeAlgorithmInvocation({ row: { __index: 5 }, results: [] }, {
+    algorithmId: 'ocl-semantic',
+    algorithmConfig: oclSemanticAlgo,
+    projectContext,
+    rowIndex: 5
+  })
+
+  assert.equal(out.candidates.length, 0)
+  assert.equal(out.concept_definitions.length, 0)
+  assert.equal(out.concept_rows.length, 0)
+  assert.equal(out.algorithm_response.algorithm_id, 'ocl-semantic')
+  assert.equal(out.algorithm_response.status, 'success')
+})
+
+test('invocation with failure status records the error on AlgorithmResponse', () => {
+  const out = normalizeAlgorithmInvocation(null, {
+    algorithmId: 'ocl-search',
+    algorithmConfig: oclSearchAlgo,
+    projectContext,
+    rowIndex: 2,
+    status: 'failed',
+    error: 'HTTP 500',
+    rawResponse: { detail: 'HTTP 500' }
+  })
+
+  assert.equal(out.algorithm_response.status, 'failed')
+  assert.equal(out.algorithm_response.error, 'HTTP 500')
+  assert.deepEqual(out.algorithm_response.raw, { detail: 'HTTP 500' })
+  assert.equal(out.candidates.length, 0)
+})
+
+// ---------- Multi-algo convergence ----------
+
+test('multi-algo: same concept from ocl-search and ocl-semantic produces matching keys', () => {
+  const a = normalizeAlgorithmInvocation(
+    { row: { __index: 0 }, results: [oclSearchResult_LOINC_glucose_full] },
+    { algorithmId: 'ocl-search', algorithmConfig: oclSearchAlgo, projectContext, rowIndex: 0 }
+  )
+  const b = normalizeAlgorithmInvocation(
+    { row: { __index: 0 }, results: [oclSemanticResult_LOINC_glucose_full] },
+    { algorithmId: 'ocl-semantic', algorithmConfig: oclSemanticAlgo, projectContext, rowIndex: 0 }
+  )
+
+  assert.equal(a.candidates[0].concept_key, b.candidates[0].concept_key)
+  assert.equal(a.candidates[0].algorithm_id, 'ocl-search')
+  assert.equal(b.candidates[0].algorithm_id, 'ocl-semantic')
+  assert.equal(a.candidates[0].score, 0.85)
+  assert.equal(b.candidates[0].score, 0.91)
+})

--- a/src/components/map-projects/algorithms.jsx
+++ b/src/components/map-projects/algorithms.jsx
@@ -17,7 +17,15 @@ export const useAlgos = (t, toggles) => {
       },
       'disabled': !toggles.SEMANTIC_SEARCH_TOGGLE,
       'allow_multiple': false,
-      'lookup_required': false
+      'lookup_required': false,
+      // Canonical concept identity (plans/unified-mapper-model.md). Concepts
+      // returned by ocl-semantic come from the project's target repo, so the
+      // canonical URL of each concept is the target repo's canonical URL.
+      'concept_identity': {
+        'reference_source': 'target_repo',
+        'code_field': 'id',
+        'ocl_url_field': 'url'
+      }
     },
     {
       'id': 'ocl-search',
@@ -30,7 +38,12 @@ export const useAlgos = (t, toggles) => {
       'concurrent_requests': 2,
       'disabled': false,
       'allow_multiple': false,
-      'lookup_required': false
+      'lookup_required': false,
+      'concept_identity': {
+        'reference_source': 'target_repo',
+        'code_field': 'id',
+        'ocl_url_field': 'url'
+      }
     },
   ]
   return algos

--- a/src/components/map-projects/conceptKey.js
+++ b/src/components/map-projects/conceptKey.js
@@ -1,0 +1,54 @@
+/**
+ * Helpers for the opaque internal pool key used to index ConceptDefinitions
+ * and ConceptRows by canonical concept identity.
+ *
+ * See plans/unified-mapper-model.md (the "key" and FHIR alignment notes
+ * section). This file is the only place that knows the on-the-wire format
+ * of the key. Components must use makeConceptKey / parseConceptKey rather
+ * than constructing or splitting strings themselves.
+ *
+ * Why opaque: a key like `${url}|${code}` would collide with FHIR canonical
+ * URL syntax (where `|` is the version separator: `http://loinc.org|2.74`).
+ * Using JSON.stringify of an array sidesteps this and lets us extend with
+ * version transparently.
+ */
+
+/**
+ * @typedef {Object} ConceptReference
+ * @property {string} url - canonical URL of the code system
+ * @property {string} code - the concept code
+ * @property {string} [version] - optional code system version
+ */
+
+/**
+ * Produce the internal pool key for a ConceptReference.
+ * @param {ConceptReference} reference
+ * @returns {string}
+ */
+export const makeConceptKey = (reference) => {
+  if (!reference || typeof reference.url !== 'string' || typeof reference.code !== 'string') {
+    throw new TypeError('makeConceptKey requires a ConceptReference with url and code')
+  }
+  return JSON.stringify([reference.url, reference.code, reference.version ?? null])
+}
+
+/**
+ * Recover the ConceptReference from an internal pool key.
+ * @param {string} key
+ * @returns {ConceptReference}
+ */
+export const parseConceptKey = (key) => {
+  const [url, code, version] = JSON.parse(key)
+  return version === null ? { url, code } : { url, code, version }
+}
+
+/**
+ * Compare two references for canonical equality (ignoring undefined version).
+ * @param {ConceptReference} a
+ * @param {ConceptReference} b
+ * @returns {boolean}
+ */
+export const referencesEqual = (a, b) => {
+  if (!a || !b) return false
+  return a.url === b.url && a.code === b.code && (a.version ?? null) === (b.version ?? null)
+}

--- a/src/components/map-projects/normalizers.js
+++ b/src/components/map-projects/normalizers.js
@@ -1,0 +1,332 @@
+/* eslint-disable no-undef */
+/**
+ * Pure normalization functions for the unified mapper data model.
+ * See plans/unified-mapper-model.md for the architectural rationale.
+ *
+ * Splits the legacy flat candidate-shaped object returned by match algorithms
+ * into four entities:
+ *   - AlgorithmResponse: raw algorithm output (preserved verbatim)
+ *   - Candidate:         a claim that a concept matches a row, per algorithm
+ *   - ConceptDefinition: project-wide canonical concept data (lives in conceptCache)
+ *   - ConceptRow:        per-row presence of a concept (rerank_score lives here)
+ *
+ * Concept identity is canonical: ConceptReference = {url, code, version?}, where
+ * `url` is the canonical URL of the code system (NOT the OCL relative URL of an
+ * instance). Each algorithm declares how to extract the reference from its
+ * response via a `concept_identity` config block; the normalizer resolves
+ * `reference_source: 'target_repo' | 'bridge_repo' | 'fixed'` against the
+ * project context.
+ *
+ * These functions intentionally have no React or lodash dependencies — they
+ * are unit-testable in isolation against captured algorithm fixtures.
+ */
+
+import { makeConceptKey } from './conceptKey.js'
+
+const newId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `id-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+/**
+ * Create an AlgorithmResponse entity wrapping the raw algorithm output.
+ * Preserves the response untouched so debug/audit views can render it later.
+ */
+export const createAlgorithmResponse = (rawResponse, algorithmId, options = {}) => {
+  const { status = 'success', error, rowIndex } = options
+  return {
+    id: newId(),
+    algorithm_id: algorithmId,
+    row_index: rowIndex,
+    raw: rawResponse,
+    received_at: new Date().toISOString(),
+    status,
+    ...(error ? { error } : {})
+  }
+}
+
+/**
+ * Decide a concept's lookup_status based on which fields the algorithm response
+ * populated.
+ */
+const inferLookupStatus = (result) => {
+  if (!result) return 'pending'
+  const hasNames = Array.isArray(result.names) && result.names.length > 0
+  const hasDescriptions = Array.isArray(result.descriptions) && result.descriptions.length > 0
+  if (hasNames && hasDescriptions) return 'full'
+  if (result.id && result.display_name) return 'partial'
+  return 'pending'
+}
+
+/**
+ * Resolve a ConceptReference from a result given an identity config and project context.
+ *
+ * @param {Object} result            One algorithm result (concept-shaped).
+ * @param {Object} identityConfig    The algorithm's concept_identity config block.
+ *                                   Shape: { reference_source, code_field, canonical_url? }
+ * @param {Object} projectContext    Project-level canonical context.
+ *                                   Shape: { target_repo: {canonical_url, version?},
+ *                                            bridge_repo?: {canonical_url, version?} }
+ * @returns {ConceptReference | null}
+ */
+const resolveReference = (result, identityConfig, projectContext) => {
+  if (!result || !identityConfig) return null
+  const codeField = identityConfig.code_field || 'id'
+  const code = result[codeField]
+  if (!code) return null
+
+  let url
+  let version
+  switch (identityConfig.reference_source) {
+    case 'fixed':
+      url = identityConfig.canonical_url
+      break
+    case 'target_repo':
+      url = projectContext?.target_repo?.canonical_url
+      version = projectContext?.target_repo?.version
+      break
+    case 'bridge_repo':
+      url = projectContext?.bridge_repo?.canonical_url
+      version = projectContext?.bridge_repo?.version
+      break
+    default:
+      return null
+  }
+
+  if (!url) return null
+  return version ? { url, code, version } : { url, code }
+}
+
+/**
+ * Build a ConceptDefinition from a concept-shaped result + a resolved reference.
+ */
+const toConceptDefinition = (result, reference, identityConfig, { algorithmId } = {}) => {
+  if (!reference) return null
+  const oclUrlField = identityConfig?.ocl_url_field
+  const oclUrl = oclUrlField ? result?.[oclUrlField] : undefined
+  return {
+    reference,
+    key: makeConceptKey(reference),
+    ocl_url: oclUrl,
+    id: result?.id,
+    display_name: result?.display_name,
+    source: result?.source,
+    owner: result?.owner,
+    names: result?.names,
+    descriptions: result?.descriptions,
+    concept_class: result?.concept_class,
+    datatype: result?.datatype,
+    retired: result?.retired,
+    properties: result?.properties,
+    lookup_status: inferLookupStatus(result),
+    lookup_source_type: 'algorithm',
+    lookup_source: algorithmId
+  }
+}
+
+/**
+ * Build a stub ConceptDefinition for a bridge cascade target. Bridge responses
+ * only carry name+code+url for cascade targets, so the resulting definition is
+ * always 'pending' — ensureLoaded will fill it in.
+ *
+ * @param {Object} mapping             A cascade mapping entry from the bridge response.
+ * @param {Object} cascadeIdentity     The algo's concept_identity.cascade_target config.
+ * @param {Object} projectContext
+ */
+const cascadeTargetToConceptDefinition = (mapping, cascadeIdentity, projectContext) => {
+  if (!mapping || !cascadeIdentity) return null
+  // Build a synthetic "result" shape so resolveReference can run uniformly.
+  const syntheticResult = {
+    [cascadeIdentity.code_field || 'cascade_target_concept_code']:
+      mapping[cascadeIdentity.code_field || 'cascade_target_concept_code'],
+    ...mapping
+  }
+  const reference = resolveReference(syntheticResult, cascadeIdentity, projectContext)
+  if (!reference) return null
+
+  const oclUrlField = cascadeIdentity.ocl_url_field
+  const oclUrl = oclUrlField ? mapping?.[oclUrlField] : undefined
+
+  return {
+    reference,
+    key: makeConceptKey(reference),
+    ocl_url: oclUrl,
+    id: reference.code,
+    display_name: mapping.cascade_target_concept_name,
+    source: mapping.cascade_target_source_name,
+    owner: undefined,
+    names: undefined,
+    descriptions: undefined,
+    concept_class: undefined,
+    datatype: undefined,
+    retired: undefined,
+    properties: undefined,
+    lookup_status: 'pending',
+    lookup_source_type: undefined,
+    lookup_source: undefined
+  }
+}
+
+const newConceptRow = (conceptKey) => ({
+  concept_key: conceptKey,
+  rerank_score: undefined
+})
+
+const isBridgeResult = (identityConfig) =>
+  identityConfig?.reference_source === 'bridge_repo' && Boolean(identityConfig.cascade_target)
+
+/**
+ * Normalize a single algorithm result into the new entity model.
+ *
+ * @param {Object} result            One result object (concept-shaped).
+ * @param {Object} ctx               Normalization context.
+ * @param {string} ctx.algorithmId   The algorithm ID (e.g. 'ocl-search').
+ * @param {Object} ctx.algorithmConfig         The algorithm definition with concept_identity.
+ * @param {string} ctx.algorithmResponseId     FK back to the AlgorithmResponse.
+ * @param {Object} ctx.projectContext          {target_repo, bridge_repo?, namespace}
+ * @returns {{candidates: Array, concept_definitions: Array, concept_rows: Array}}
+ */
+export const normalizeAlgoResult = (result, ctx = {}) => {
+  const empty = { candidates: [], concept_definitions: [], concept_rows: [] }
+  if (!result) return empty
+
+  const { algorithmId, algorithmConfig, algorithmResponseId, projectContext } = ctx
+  const identityConfig = algorithmConfig?.concept_identity
+  if (!identityConfig) return empty
+
+  const meta = result.search_meta || {}
+  const isBridge = isBridgeResult(identityConfig)
+
+  // Resolve the primary reference (the result's own concept).
+  const primaryReference = resolveReference(result, identityConfig, projectContext)
+  if (!primaryReference) return empty
+
+  const candidates = []
+  const conceptDefinitions = []
+  const conceptRows = []
+
+  const primaryDef = toConceptDefinition(result, primaryReference, identityConfig, { algorithmId })
+  conceptDefinitions.push(primaryDef)
+  conceptRows.push(newConceptRow(primaryDef.key))
+
+  const primaryCandidate = {
+    id: newId(),
+    algorithm_response_id: algorithmResponseId,
+    algorithm_id: algorithmId,
+    concept_key: primaryDef.key,
+    type: isBridge ? 'bridge' : 'standard',
+    score: meta.search_score,
+    highlights: meta.search_highlight
+  }
+  candidates.push(primaryCandidate)
+
+  // For bridge results, fan out one bridge_child candidate per cascade mapping.
+  if (isBridge && Array.isArray(result.mappings)) {
+    for (const mapping of result.mappings) {
+      const targetDef = cascadeTargetToConceptDefinition(
+        mapping,
+        identityConfig.cascade_target,
+        projectContext
+      )
+      if (!targetDef) continue
+
+      // Avoid duplicate ConceptDefinition entries within the same result.
+      if (!conceptDefinitions.some(cd => cd.key === targetDef.key)) {
+        conceptDefinitions.push(targetDef)
+        conceptRows.push(newConceptRow(targetDef.key))
+      }
+
+      candidates.push({
+        id: newId(),
+        algorithm_response_id: algorithmResponseId,
+        algorithm_id: algorithmId,
+        concept_key: targetDef.key,
+        type: 'bridge_child',
+        score: undefined,
+        highlights: undefined,
+        bridge_concept_key: primaryDef.key,
+        parent_candidate_id: primaryCandidate.id,
+        map_type: mapping.map_type
+      })
+    }
+  }
+
+  return {
+    candidates,
+    concept_definitions: conceptDefinitions,
+    concept_rows: conceptRows
+  }
+}
+
+/**
+ * Higher-level orchestration: normalize a full algorithm invocation for one row.
+ * Takes the wrapped `{row, results}` payload and produces the AlgorithmResponse +
+ * flattened entity arrays, with intra-payload dedup.
+ *
+ * @param {Object} rawPayload                    The {row, results} envelope.
+ * @param {Object} ctx
+ * @param {string} ctx.algorithmId
+ * @param {Object} ctx.algorithmConfig
+ * @param {Object} ctx.projectContext
+ * @param {number} ctx.rowIndex
+ * @param {string} [ctx.status='success']
+ * @param {string} [ctx.error]
+ * @param {*}      [ctx.rawResponse]             Override stored raw (defaults to rawPayload).
+ */
+export const normalizeAlgorithmInvocation = (rawPayload, ctx = {}) => {
+  const {
+    algorithmId,
+    algorithmConfig,
+    projectContext,
+    rowIndex,
+    status = 'success',
+    error,
+    rawResponse
+  } = ctx
+
+  const algorithmResponse = createAlgorithmResponse(
+    rawResponse !== undefined ? rawResponse : rawPayload,
+    algorithmId,
+    { status, error, rowIndex }
+  )
+
+  const results = Array.isArray(rawPayload?.results) ? rawPayload.results : []
+
+  const allCandidates = []
+  const defsByKey = new Map()
+  const rowsByKey = new Map()
+
+  for (const result of results) {
+    const { candidates, concept_definitions, concept_rows } = normalizeAlgoResult(result, {
+      algorithmId,
+      algorithmConfig,
+      algorithmResponseId: algorithmResponse.id,
+      projectContext
+    })
+    allCandidates.push(...candidates)
+    for (const cd of concept_definitions) {
+      const existing = defsByKey.get(cd.key)
+      // Prefer richer definitions: never overwrite a 'full' with a 'pending'.
+      if (!existing || lookupStatusRank(cd.lookup_status) > lookupStatusRank(existing.lookup_status)) {
+        defsByKey.set(cd.key, cd)
+      }
+    }
+    for (const cr of concept_rows) {
+      if (!rowsByKey.has(cr.concept_key)) {
+        rowsByKey.set(cr.concept_key, cr)
+      }
+    }
+  }
+
+  return {
+    algorithm_response: algorithmResponse,
+    candidates: allCandidates,
+    concept_definitions: Array.from(defsByKey.values()),
+    concept_rows: Array.from(rowsByKey.values())
+  }
+}
+
+const LOOKUP_RANK = { pending: 0, failed: 0, partial: 1, full: 2 }
+export const lookupStatusRank = (status) => LOOKUP_RANK[status] ?? 0

--- a/src/components/map-projects/normalizers.js
+++ b/src/components/map-projects/normalizers.js
@@ -224,13 +224,13 @@ export const normalizeAlgoResult = (result, ctx = {}) => {
 
   // For bridge results, fan out one bridge_child candidate per cascade mapping.
   if (isBridge && Array.isArray(result.mappings)) {
-    for (const mapping of result.mappings) {
+    result.mappings.forEach(mapping => {
       const targetDef = cascadeTargetToConceptDefinition(
         mapping,
         identityConfig.cascade_target,
         projectContext
       )
-      if (!targetDef) continue
+      if (!targetDef) return
 
       // Avoid duplicate ConceptDefinition entries within the same result.
       if (!conceptDefinitions.some(cd => cd.key === targetDef.key)) {
@@ -250,7 +250,7 @@ export const normalizeAlgoResult = (result, ctx = {}) => {
         parent_candidate_id: primaryCandidate.id,
         map_type: mapping.map_type
       })
-    }
+    })
   }
 
   return {
@@ -298,7 +298,7 @@ export const normalizeAlgorithmInvocation = (rawPayload, ctx = {}) => {
   const defsByKey = new Map()
   const rowsByKey = new Map()
 
-  for (const result of results) {
+  results.forEach(result => {
     const { candidates, concept_definitions, concept_rows } = normalizeAlgoResult(result, {
       algorithmId,
       algorithmConfig,
@@ -306,19 +306,19 @@ export const normalizeAlgorithmInvocation = (rawPayload, ctx = {}) => {
       projectContext
     })
     allCandidates.push(...candidates)
-    for (const cd of concept_definitions) {
+    concept_definitions.forEach(cd => {
       const existing = defsByKey.get(cd.key)
       // Prefer richer definitions: never overwrite a 'full' with a 'pending'.
       if (!existing || lookupStatusRank(cd.lookup_status) > lookupStatusRank(existing.lookup_status)) {
         defsByKey.set(cd.key, cd)
       }
-    }
-    for (const cr of concept_rows) {
+    })
+    concept_rows.forEach(cr => {
       if (!rowsByKey.has(cr.concept_key)) {
         rowsByKey.set(cr.concept_key, cr)
       }
-    }
-  }
+    })
+  })
 
   return {
     algorithm_response: algorithmResponse,


### PR DESCRIPTION
## Summary

PR1 of the row-scoped, canonical-URL-identified candidate/concept refactor for OCL Mapper. Introduces the new entity model (AlgorithmResponse, Candidate, ConceptDefinition, ConceptRow) and the normalizer that produces it, behind a feature flag that is **OFF by default**. Reads still come from legacy `allCandidates` — flipping reads is PR2.

Spec: [unified-mapper-model.md](https://github.com/OpenConceptLab/ocl-online-docs/blob/main/mapper/unified-mapper-model.md) — full design rationale, key decisions, and implementation status table.

References OpenConceptLab/ocl_issues#2337 (does not yet close — PR1 of 3).

## What's in this PR

**New files:**
- `src/components/map-projects/normalizers.js` — pure `normalizeAlgoResult` / `normalizeAlgorithmInvocation`. Resolves canonical `ConceptReference {url, code, version?}` per algorithm's `concept_identity` config (`target_repo` / `bridge_repo` / `fixed`). Produces the four entities with intra-invocation dedup (richer ConceptDefinition wins).
- `src/components/map-projects/conceptKey.js` — opaque pool key helpers. Avoids the FHIR canonical `|version` collision that would arise from concatenating `url|code`.
- `src/components/map-projects/__tests__/normalizers.test.js` — 26 unit tests (Node `node:test`, no new framework dependency).

**Modified:**
- `src/components/map-projects/algorithms.jsx` — `concept_identity` block on `ocl-search` and `ocl-semantic`.
- `src/components/map-projects/MapProject.jsx` — `UNIFIED_MODEL_ENABLED` feature flag (default OFF), parallel `rowMatchState` hook, `mergeIntoRowMatchState` callback, `buildProjectContext` (reads `repo.canonical_url` or derives `https://ns.openconceptlab.org{url}`), flag-gated normalize-and-merge in `onResponse` (success + failure paths).
- `package.json` — `npm test` script using built-in `node --test`.

## Verification

- `npm test` → 26/26 passing
- `npm run eslint` → clean
- `npm run build` → webpack compiled successfully (after `npm install` to sync recent package updates)
- Smoke: with the flag off, runtime behavior is unchanged

## Test plan

- [ ] Code review the normalizer + tests against the spec linked above
- [ ] CI: `npm install`, `npm test`, `npm run eslint`, `npm run build` all green
- [ ] Smoke test: load Mapper, run candidates on an existing project, save/reload — should be indistinguishable from main
- [ ] (Optional) Flag-on dev session: temporarily set `UNIFIED_MODEL_ENABLED = true` locally, run candidates, inspect `rowMatchState` in React DevTools, capture one real `$match` response and confirm shape matches the synthesized fixtures in the test file. Don't merge with the flag on.

## Deferred to follow-up PRs

- **PR 2** — flip reads (`Candidates.jsx`, `Concept.jsx`, `Score.jsx`, `SearchHighlightsDialog.jsx`, `AICandidatesAnalysis.jsx`, `MapButton.jsx`); wire bridge and scispacy code paths into the normalizer; add `canonical_url` field to custom-algo config UI; surface canonical context in `ConfigurationForm.jsx`; rebuild `$lookup` as `ensureLoaded` over `$resolveReference`; remove `match_type`.
- **PR 3** — flip writes; remove legacy `allCandidates`; ship schema-v2 save format with `normalizeLegacy.js` for backward-compatible load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)