### PR TITLE
PR3-X.2 | Drop inherited version slot on bridge cascade-target references

### DIFF
--- a/src/components/map-projects/__tests__/normalizers.test.js
+++ b/src/components/map-projects/__tests__/normalizers.test.js
@@ -610,6 +610,118 @@ test('bridge result with multiple cascade targets fans out 1 + N candidates', ()
   }
 })
 
+// ---------- PR3-X.2: bridge cascade target version-slot dedup ----------
+//
+// Regression guard for OpenConceptLab/ocl_issues#2520. When the project's
+// target_repo carries a `version` field (commonly "HEAD" in production
+// projects pinned at the head of the source), the cascade target previously
+// inherited that version onto its reference. Direct-search matches against
+// the same (url, code) arrive without a version slot, so the two paths
+// produced different concept_keys (`[…,"HEAD"]` vs `[…,null]`) and
+// `defsByKey` / `recommendable_concepts` saw two entries instead of one.
+//
+// Fix: cascadeTargetToConceptDefinition drops the inherited version slot
+// unconditionally. These tests assert that fix at the normalizer layer; the
+// downstream effect (one entry in `recommendable_concepts` with two pieces of
+// evidence) follows from `buildV2RecommendationPayload`'s pre-existing
+// key-based dedup.
+
+test('cascade target reference does not inherit target_repo.version, even when set', () => {
+  const out = normalizeAlgoResult(bridgeResult_CIEL_to_LOINC, {
+    algorithmId: 'ocl-bridge',
+    algorithmConfig: oclBridgeAlgo,
+    algorithmResponseId: 'ar-pinned',
+    projectContext: {
+      ...projectContext,
+      target_repo: { ...projectContext.target_repo, version: 'HEAD' }
+    }
+  })
+
+  const targetDef = out.concept_definitions.find(d => d.reference.code === '49494-3')
+  assert.ok(targetDef, 'cascade target ConceptDefinition was emitted')
+  assert.equal(targetDef.reference.version, undefined,
+    'cascade-target reference must NOT carry the inherited target_repo.version sentinel')
+  assert.deepEqual(targetDef.reference, { url: 'http://loinc.org', code: '49494-3' })
+})
+
+test('bridge cascade target key matches direct fixed-canonical match key under pinned target_repo.version', () => {
+  // Same (url, code) — '49494-3' on http://loinc.org — arriving via two paths:
+  // (a) ocl-bridge cascade target on a CIEL bridge result (resolves via
+  //     target_repo, so pre-fix inherited target_repo.version="HEAD")
+  // (b) ocl-scispacy direct match (resolves via fixed canonical, no version)
+  // Pre-fix the keys diverged (`[…,"HEAD"]` vs `[…,null]`) and the LLM saw
+  // the concept twice with split evidence. Post-fix the cascade target drops
+  // the inherited version, so both paths key on the same canonical (url, code).
+  const pinnedCtx = {
+    ...projectContext,
+    target_repo: { ...projectContext.target_repo, version: 'HEAD' }
+  }
+
+  const bridgeOut = normalizeAlgoResult(bridgeResult_CIEL_to_LOINC, {
+    algorithmId: 'ocl-bridge',
+    algorithmConfig: oclBridgeAlgo,
+    algorithmResponseId: 'ar-bridge',
+    projectContext: pinnedCtx
+  })
+  // Scispacy fixture has the same code (49494-3) on the same canonical
+  // (http://loinc.org via reference_source='fixed').
+  const directOut = normalizeAlgoResult(scispacyResult_partial, {
+    algorithmId: 'ocl-scispacy-loinc',
+    algorithmConfig: oclScispacyAlgo,
+    algorithmResponseId: 'ar-direct',
+    projectContext: pinnedCtx
+  })
+
+  const cascadeTargetDef = bridgeOut.concept_definitions.find(d => d.reference.code === '49494-3')
+  const directDef = directOut.concept_definitions.find(d => d.reference.code === '49494-3')
+
+  assert.ok(cascadeTargetDef && directDef)
+  assert.equal(cascadeTargetDef.key, directDef.key,
+    'cascade target and fixed-canonical direct match must share a concept_key for dedup')
+  assert.equal(cascadeTargetDef.key, makeConceptKey({ url: 'http://loinc.org', code: '49494-3' }),
+    'shared key is the version-less canonical key')
+})
+
+test('bridge cascade target collides with direct fixed-canonical match in defsByKey dedup', () => {
+  // Models the defsByKey dedup in buildV2RecommendationPayload (MapProject.jsx).
+  // With the fix, candidates from the two paths collapse to ONE map entry, and
+  // the bridge_child + standard evidence converges onto a single recommendable.
+  const pinnedCtx = {
+    ...projectContext,
+    target_repo: { ...projectContext.target_repo, version: 'HEAD' }
+  }
+  const bridgeOut = normalizeAlgoResult(bridgeResult_CIEL_to_LOINC, {
+    algorithmId: 'ocl-bridge',
+    algorithmConfig: oclBridgeAlgo,
+    algorithmResponseId: 'ar-bridge',
+    projectContext: pinnedCtx
+  })
+  const directOut = normalizeAlgoResult(scispacyResult_partial, {
+    algorithmId: 'ocl-scispacy-loinc',
+    algorithmConfig: oclScispacyAlgo,
+    algorithmResponseId: 'ar-direct',
+    projectContext: pinnedCtx
+  })
+
+  const allCandidates = [...bridgeOut.candidates, ...directOut.candidates]
+  const allDefs = [...bridgeOut.concept_definitions, ...directOut.concept_definitions]
+
+  const defsByKey = new Map()
+  for (const def of allDefs) defsByKey.set(def.key, def)
+
+  const targetKey = makeConceptKey({ url: 'http://loinc.org', code: '49494-3' })
+  assert.ok(defsByKey.has(targetKey), 'shared target key is in the dedup map')
+
+  // Two evidence-bearing candidates point at the target key: one bridge_child
+  // (from ocl-bridge) and one standard (from ocl-scispacy). Pre-fix these were
+  // keyed differently and the evidence never converged.
+  const evidenceForTarget = allCandidates.filter(c => c.concept_key === targetKey)
+  assert.equal(evidenceForTarget.length, 2,
+    'one bridge_child + one direct candidate converge on the same concept_key')
+  assert.ok(evidenceForTarget.some(c => c.type === 'bridge_child'))
+  assert.ok(evidenceForTarget.some(c => c.type === 'standard'))
+})
+
 // ---------- normalizeAlgorithmInvocation ----------
 
 test('invocation wraps a multi-result payload into one AlgorithmResponse + flat entities', () => {

--- a/src/components/map-projects/normalizers.js
+++ b/src/components/map-projects/normalizers.js
@@ -161,8 +161,13 @@ const cascadeTargetToConceptDefinition = (mapping, cascadeIdentity, projectConte
       mapping[cascadeIdentity.code_field || 'cascade_target_concept_code'],
     ...mapping
   }
-  const reference = resolveReference(syntheticResult, cascadeIdentity, projectContext)
-  if (!reference) return null
+  const resolved = resolveReference(syntheticResult, cascadeIdentity, projectContext)
+  if (!resolved) return null
+  // Drop the inherited target_repo.version slot. The cascade target is a stub
+  // identified by (url, code); the project's repo pin (often "HEAD") is not a
+  // per-concept version and including it would split the concept_key from a
+  // direct-path match against the same (url, code).
+  const reference = { url: resolved.url, code: resolved.code }
 
   const oclUrlField = cascadeIdentity.ocl_url_field
   const oclUrl = oclUrlField ? mapping?.[oclUrlField] : undefined


### PR DESCRIPTION
Closes OpenConceptLab/ocl_issues#2520. Refs OpenConceptLab/ocl_issues#2337.

## Summary

`cascadeTargetToConceptDefinition` (called `toBridgeChildConceptDefinition` in the master plan) inherits `projectContext.target_repo.version` onto the cascade-target's reference via `resolveReference`. Production projects pinned at `"HEAD"` end up with `["…","HEAD"]` in the version slot of the cascade-target's `concept_key`. Direct fixed-canonical matches against the same (url, code) arrive with `null` in that slot, so the two paths produce different keys, `defsByKey` in `buildV2RecommendationPayload` treats them as distinct entries, the LLM sees the same concept twice with split evidence, and the v2 prompt payload bloats.

This PR drops the inherited version slot on cascade-target references unconditionally. `"HEAD"` is the project repo pin, not a per-concept version, and the cascade-target stub is re-resolved via `ensureLoaded` anyway. Aligning both paths on no-version is cleaner than pinning both to a sentinel.

## Diff

- [src/components/map-projects/normalizers.js](src/components/map-projects/normalizers.js#L156-L190) — in `cascadeTargetToConceptDefinition`, build the final `reference` as `{url, code}` from the resolved reference, discarding any inherited `version`.
- [src/components/map-projects/__tests__/normalizers.test.js](src/components/map-projects/__tests__/normalizers.test.js) — three new tests under a "PR3-X.2: bridge cascade target version-slot dedup" section.

## Tests

89/89 pass. The new tests cover:

1. **Cascade target reference does not inherit target_repo.version, even when set.** Asserts the surgical fix.
2. **Bridge cascade target key matches direct fixed-canonical match key under pinned target_repo.version="HEAD".** Authentic prod scenario — `ocl-bridge` cascade target vs `ocl-scispacy-loinc` (fixed canonical) on the same `(http://loinc.org, 49494-3)`. Pre-fix: different keys; post-fix: same key.
3. **Bridge cascade target collides with direct fixed-canonical match in `defsByKey` dedup.** Proxies the dedup logic in `buildV2RecommendationPayload`: one bridge_child + one standard candidate converge on the same `concept_key`, exactly the "evidence.length === 2" outcome the master plan calls for. `buildV2RecommendationPayload` itself isn't unit-testable as written (closure inside the React component); this is the closest layer below that's pure.

eslint clean.

## Why two slices for X.1 + X.2

X.1 (audit trail in ocl-ai-assistant, [#139](https://github.com/OpenConceptLab/ocl-ai-assistant/pull/139)) and X.2 (this one) are both visibility/auditability fixes that need to land before PR3-D1's payload trim so we can read the before/after diff cleanly in Django admin.

## Coordination with PR3-G

PR3-G fixes the orthogonal "merge didn't happen because one entry was thinner" bug (`mergeIntoRowMatchState` richer-wins). This PR fixes "merge didn't happen because the keys never collided" (key construction). Both need to land for the LLM to see a single deduplicated entry per concept with all evidence converged.

## Context

Part of the post-PR2b OCL Mapper unification close-out. See `ocl-online-docs/mapper/unified-mapper-model.md` -> "PR3 Implementation Plan" -> "PR3-X.2" for the slice spec.

## Test plan

- [ ] Merge.
- [ ] In staging, open a project with `target_repo.version` pinned (e.g., LOINC at "HEAD") and a row that produces both a bridge cascade hit and a direct fixed-canonical match on the same target concept. Trigger AI Assistant.
- [ ] Inspect the staging POST body to `/prompts/.../invoke/`: `recommendable_concepts[]` has ONE entry for that concept with `evidence.length === 2` (one `bridge_child` + one direct).
- [ ] Combined with X.1 already shipped, the audit-trail's `input_variables` vs `processed_variables` shows the dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)