### PR TITLE
PR3-X.2 | Align fixed-canonical algos to project target_repo.version

### DIFF
--- a/src/components/map-projects/__tests__/normalizers.test.js
+++ b/src/components/map-projects/__tests__/normalizers.test.js
@@ -727,3 +727,177 @@ test('multi-algo: same concept from ocl-search and ocl-semantic produces matchin
   assert.equal(a.candidates[0].score, 0.85)
   assert.equal(b.candidates[0].score, 0.91)
 })
+
+// ---------- target_repo version alignment across algorithm paths (#2520) ----------
+//
+// A mapping project pins to ONE explicit target_repo version. Concept identity
+// for dedup must be anchored to that pin across ALL algorithm paths that hit
+// the same target repo:
+//   - target_repo reference_source (ocl-search, ocl-semantic) — inherits pin via projectContext
+//   - bridge_repo cascade_target (ocl-bridge cascade hits) — inherits pin via the cascade's target_repo branch
+//   - fixed reference_source (ocl-scispacy) whose canonical_url matches the project's target_repo
+//     — must also inherit the pin so it dedups with the other paths
+//
+// Without the fixed-branch inheritance, scispacy LOINC produced concept_keys
+// with `version: null` while every other path keyed on the project's pin
+// (e.g. "2.81"), splitting the same logical concept into separate
+// recommendable_concepts entries with split evidence in the v2 LLM payload.
+
+test('fixed-canonical algo whose URL matches target_repo inherits the project version pin', () => {
+  const pinnedCtx = {
+    ...projectContext,
+    target_repo: { ...projectContext.target_repo, version: '2.81' }
+  }
+  const out = normalizeAlgoResult(scispacyResult_partial, {
+    algorithmId: 'ocl-scispacy-loinc',
+    algorithmConfig: oclScispacyAlgo,
+    algorithmResponseId: 'ar-scispacy',
+    projectContext: pinnedCtx
+  })
+
+  const def = out.concept_definitions.find(d => d.reference.code === '49494-3')
+  assert.ok(def, 'scispacy ConceptDefinition was emitted')
+  assert.equal(def.reference.version, '2.81',
+    'fixed canonical matching target_repo must inherit the project version pin')
+  assert.deepEqual(def.reference, { url: 'http://loinc.org', code: '49494-3', version: '2.81' })
+})
+
+test('all algorithm paths converge on the same concept_key under a pinned target_repo version', () => {
+  // Released-version pin (the common case). Four paths hit the same LOINC
+  // concept and must produce identical concept_keys for dedup to work:
+  //   1. ocl-search direct  (target_repo)
+  //   2. ocl-semantic direct (target_repo)
+  //   3. ocl-bridge cascade target (target_repo via cascade)
+  //   4. ocl-scispacy direct (fixed canonical matching target_repo)
+  const pinnedCtx = {
+    ...projectContext,
+    target_repo: { ...projectContext.target_repo, version: '2.81' }
+  }
+
+  const searchOut = normalizeAlgoResult(oclSearchResult_LOINC_glucose_full, {
+    algorithmId: 'ocl-search',
+    algorithmConfig: oclSearchAlgo,
+    algorithmResponseId: 'ar-search',
+    projectContext: pinnedCtx
+  })
+  const semanticOut = normalizeAlgoResult(oclSemanticResult_LOINC_glucose_full, {
+    algorithmId: 'ocl-semantic',
+    algorithmConfig: oclSemanticAlgo,
+    algorithmResponseId: 'ar-semantic',
+    projectContext: pinnedCtx
+  })
+  const bridgeOut = normalizeAlgoResult(bridgeResult_CIEL_to_LOINC, {
+    algorithmId: 'ocl-bridge',
+    algorithmConfig: oclBridgeAlgo,
+    algorithmResponseId: 'ar-bridge',
+    projectContext: pinnedCtx
+  })
+  const scispacyOut = normalizeAlgoResult(scispacyResult_partial, {
+    algorithmId: 'ocl-scispacy-loinc',
+    algorithmConfig: oclScispacyAlgo,
+    algorithmResponseId: 'ar-scispacy',
+    projectContext: pinnedCtx
+  })
+
+  const expectedKey = makeConceptKey({ url: 'http://loinc.org', code: '49494-3', version: '2.81' })
+
+  const searchDef = searchOut.concept_definitions.find(d => d.reference.code === '49494-3')
+  const semanticDef = semanticOut.concept_definitions.find(d => d.reference.code === '49494-3')
+  const bridgeCascadeDef = bridgeOut.concept_definitions.find(d => d.reference.code === '49494-3')
+  const scispacyDef = scispacyOut.concept_definitions.find(d => d.reference.code === '49494-3')
+
+  assert.ok(searchDef && semanticDef && bridgeCascadeDef && scispacyDef,
+    'all four paths emit a ConceptDefinition for the target concept')
+  assert.equal(searchDef.key, expectedKey, 'ocl-search keys on pinned version')
+  assert.equal(semanticDef.key, expectedKey, 'ocl-semantic keys on pinned version')
+  assert.equal(bridgeCascadeDef.key, expectedKey, 'ocl-bridge cascade target keys on pinned version')
+  assert.equal(scispacyDef.key, expectedKey, 'ocl-scispacy keys on pinned version (fixed→target_repo alignment)')
+})
+
+test('all paths converge under HEAD pin too (degenerate but supported)', () => {
+  // HEAD is an explicit, valid project pin — uncommon but allowed. The
+  // alignment must hold whether the pin is a released version or HEAD.
+  const headCtx = {
+    ...projectContext,
+    target_repo: { ...projectContext.target_repo, version: 'HEAD' }
+  }
+  const searchOut = normalizeAlgoResult(oclSearchResult_LOINC_glucose_full, {
+    algorithmId: 'ocl-search',
+    algorithmConfig: oclSearchAlgo,
+    algorithmResponseId: 'ar-search',
+    projectContext: headCtx
+  })
+  const bridgeOut = normalizeAlgoResult(bridgeResult_CIEL_to_LOINC, {
+    algorithmId: 'ocl-bridge',
+    algorithmConfig: oclBridgeAlgo,
+    algorithmResponseId: 'ar-bridge',
+    projectContext: headCtx
+  })
+  const scispacyOut = normalizeAlgoResult(scispacyResult_partial, {
+    algorithmId: 'ocl-scispacy-loinc',
+    algorithmConfig: oclScispacyAlgo,
+    algorithmResponseId: 'ar-scispacy',
+    projectContext: headCtx
+  })
+  const expectedKey = makeConceptKey({ url: 'http://loinc.org', code: '49494-3', version: 'HEAD' })
+
+  assert.equal(searchOut.concept_definitions.find(d => d.reference.code === '49494-3').key, expectedKey)
+  assert.equal(bridgeOut.concept_definitions.find(d => d.reference.code === '49494-3').key, expectedKey)
+  assert.equal(scispacyOut.concept_definitions.find(d => d.reference.code === '49494-3').key, expectedKey)
+})
+
+test('fixed-canonical algo whose URL does NOT match target_repo does not inherit project version', () => {
+  // Safety: the version-inheritance only applies when the fixed canonical
+  // points at the same repo as target_repo. A fixed algo targeting a
+  // different canonical (e.g. SNOMED while the project's target is LOINC)
+  // must continue to produce version-less references — those concepts live
+  // in a different repo entirely and have no relationship to the pin.
+  const pinnedCtx = {
+    ...projectContext,
+    target_repo: { ...projectContext.target_repo, version: '2.81' }
+  }
+  const snomedAlgo = {
+    id: 'custom-snomed',
+    type: 'custom',
+    concept_identity: {
+      reference_source: 'fixed',
+      canonical_url: 'http://snomed.info/sct',
+      code_field: 'id'
+    }
+  }
+  const snomedResult = {
+    id: '12345678',
+    display_name: 'Some SNOMED concept',
+    search_meta: { search_score: 0.7, algorithm: 'custom-snomed' }
+  }
+  const out = normalizeAlgoResult(snomedResult, {
+    algorithmId: 'custom-snomed',
+    algorithmConfig: snomedAlgo,
+    algorithmResponseId: 'ar-snomed',
+    projectContext: pinnedCtx
+  })
+
+  const def = out.concept_definitions.find(d => d.reference.code === '12345678')
+  assert.ok(def)
+  assert.equal(def.reference.version, undefined,
+    'fixed canonical pointing at a different repo than target_repo does NOT inherit the pin')
+  assert.deepEqual(def.reference, { url: 'http://snomed.info/sct', code: '12345678' })
+})
+
+test('fixed-canonical algo with no target_repo.version on project (unpinned) still produces version-less key', () => {
+  // Backward-compat: when the project's target_repo has no version field
+  // (legacy projects or in-flight setup), the fixed-branch inheritance is a
+  // no-op — scispacy continues to emit version-less references as before.
+  // Once the form-level "version required" validation lands (separate
+  // follow-up), this case stops occurring in production.
+  const out = normalizeAlgoResult(scispacyResult_partial, {
+    algorithmId: 'ocl-scispacy-loinc',
+    algorithmConfig: oclScispacyAlgo,
+    algorithmResponseId: 'ar-scispacy',
+    projectContext  // no target_repo.version
+  })
+  const def = out.concept_definitions.find(d => d.reference.code === '49494-3')
+  assert.ok(def)
+  assert.equal(def.reference.version, undefined)
+  assert.deepEqual(def.reference, { url: 'http://loinc.org', code: '49494-3' })
+})

--- a/src/components/map-projects/normalizers.js
+++ b/src/components/map-projects/normalizers.js
@@ -92,6 +92,17 @@ const resolveReference = (result, identityConfig, projectContext) => {
   switch (identityConfig.reference_source) {
     case 'fixed':
       url = identityConfig.canonical_url
+      // When a fixed-canonical algo's URL matches the project's target_repo,
+      // it's targeting the same repo as the target_repo-pathway algos and must
+      // key on the same (url, code, version) for dedup. Without this, e.g.
+      // scispacy LOINC (fixed) splits from ocl-search/ocl-semantic LOINC
+      // (target_repo) and from ocl-bridge cascade target (target_repo via
+      // cascade) under any pinned version. The mapping project pins ONE
+      // explicit target repo version; concept identity for dedup must be
+      // anchored to that pin across all algorithm paths.
+      if (url && url === projectContext?.target_repo?.canonical_url) {
+        version = projectContext.target_repo.version
+      }
       break
     case 'target_repo':
       url = projectContext?.target_repo?.canonical_url


### PR DESCRIPTION
Closes OpenConceptLab/ocl_issues#2520. Refs OpenConceptLab/ocl_issues#2337.

Supersedes #22 (different direction — see [\"Why this replaces #22\"](#why-this-replaces-22) below).

## Summary

A mapping project pins to ONE explicit `target_repo` version (e.g. LOINC `2.81`, occasionally `HEAD`). Concept identity for dedup must be anchored to that pin across all algorithm paths that hit the same target repo:

| Path | reference_source | Pre-fix concept_key | Post-fix concept_key |
|---|---|---|---|
| `ocl-search` direct | `target_repo` | `[…,\"49494-3\",\"2.81\"]` | `[…,\"49494-3\",\"2.81\"]` |
| `ocl-semantic` direct | `target_repo` | `[…,\"49494-3\",\"2.81\"]` | `[…,\"49494-3\",\"2.81\"]` |
| `ocl-bridge` cascade target | `target_repo` (via cascade) | `[…,\"49494-3\",\"2.81\"]` | `[…,\"49494-3\",\"2.81\"]` |
| `ocl-scispacy` direct | `fixed` canonical `http://loinc.org` | **`[…,\"49494-3\",null]`** ← split | `[…,\"49494-3\",\"2.81\"]` |

Three of four paths already converged; scispacy's `fixed`-canonical match was the outlier. Same logical concept landed twice in `recommendable_concepts[]` with split evidence, bloating the v2 LLM payload.

## Fix

In [`resolveReference`](src/components/map-projects/normalizers.js#L84-L110), extend the `fixed` branch: when the algorithm's `canonical_url` matches the project's `target_repo.canonical_url`, inherit `projectContext.target_repo.version` onto the reference. The fixed canonical is targeting the same repo as the target_repo-pathway algos; identity has to align with the project's pin to dedup cleanly.

`bridge_repo` and `target_repo` branches already do the right thing — unchanged.

## Why this replaces #22

PR #22 fixed the same symptom in the opposite direction: it *dropped* the version slot on the bridge cascade target so it would align with scispacy at `null`. That worked for the HEAD-pinned scenario in the original bug report but had two problems:

1. **Common case regressed.** For a project pinned at a released version like `2.81`, #22 pulled `bridge_child` *away* from its correct alignment with search/semantic. The split moved from `{search, semantic, bridge_child} | {scispacy}` to `{search, semantic} | {bridge_child, scispacy}`. Net worse for the typical user.
2. **`ensureLoaded` resolved against the wrong version.** With no version on the cascade target's reference, [`ensureLoaded`](src/components/map-projects/MapProject.jsx#L3311-L3313) POSTs `{url}` only to `\$resolveReference`. That endpoint resolves to \"latest released, or HEAD if no other versions exist\" — *not* to the project's pin. So in a `2.81`-pinned project, the bridge_child stub could quietly load from a different version than the rest of the project's data.

The corrected direction (align *up* to the project pin, not down to null) handles both cases correctly. `ensureLoaded` already carries `reference.version` through when present, so the stub loads from the project's pinned repo version automatically.

## Tests

91/91 pass (86 existing + 5 new). New tests under \"target_repo version alignment across algorithm paths (#2520)\":

1. **Fixed-canonical algo whose URL matches target_repo inherits the project version pin.** Asserts the surgical fix.
2. **All algorithm paths converge on the same concept_key under a pinned target_repo version.** The happy path — `2.81` pin, four-way convergence (search + semantic + bridge cascade + scispacy).
3. **All paths converge under HEAD pin too.** Degenerate but supported; the original bug report's scenario.
4. **Fixed-canonical algo whose URL does NOT match target_repo does NOT inherit project version.** Safety — a SNOMED `fixed` algo while target is LOINC must keep version-less keys.
5. **Unpinned project still produces version-less fixed-canonical keys.** Backward-compat for legacy projects with no `target_repo.version` (the case the form-validation follow-up will eliminate).

eslint clean.

## Follow-up tickets filed

- **OpenConceptLab/ocl_issues#2521** — Surface algorithm-claimed version divergence vs project pin to user. For the future case where a `\$cascade` response or external algorithm claims a different version than the project pin, we want to record and display the divergence rather than silently dropping it. Out of scope for this PR (no algorithm response carries per-result version today).
- **OpenConceptLab/ocl_issues#2522** — Require explicit `target_repo.version` on the project config form; remove the silent `'HEAD'` default at [MapProject.jsx:1060](src/components/map-projects/MapProject.jsx#L1060) and `|| undefined` default at [MapProject.jsx:693](src/components/map-projects/MapProject.jsx#L693). The mapping project's version field is already a required UI input; this ticket enforces it at the code level and removes the legacy defensive defaults.

## Coordination

- **PR3-G** (orthogonal): fixes \"merge didn't happen because one entry was thinner\" (`mergeIntoRowMatchState` richer-wins). This PR fixes \"merge didn't happen because the keys never collided\" (key construction). Both need to land for the LLM to see a single deduplicated entry per concept with all evidence converged.
- **PR3-X.1** (ocl-ai-assistant#139, merged): audit-trail snapshot in Django admin. With X.1 + this PR, `input_variables` vs `processed_variables` shows the dedup effect end-to-end.

## Test plan

- [ ] Merge.
- [ ] In staging, open a project pinned at a released LOINC version (not HEAD) with a row that produces both a bridge cascade hit and a direct scispacy hit on the same target concept. Trigger AI Assistant.
- [ ] Inspect the staging POST body to `/prompts/.../invoke/`: `recommendable_concepts[]` has ONE entry for that concept with `evidence.length >= 2` (one `bridge_child` + one `standard`).
- [ ] Repeat with a project pinned at `HEAD` to verify the degenerate case also dedupes.
- [ ] Sanity-check that bridge_child concept stubs load via `\$resolveReference` against the project's pinned version (not \"latest released\") — observable in network trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)