### PR TITLE
PR3-D1 (oclmap producer): drop legacy candidates; push property/rerank_score/retired; flip default to match-recommend-normalized

### DIFF
--- a/src/components/map-projects/MapProject.jsx
+++ b/src/components/map-projects/MapProject.jsx
@@ -98,7 +98,7 @@ import ProjectLogs from './ProjectLogs';
 import { useAlgos, CONCEPT_IDENTITY_BY_TYPE, ensureConceptIdentity } from './algorithms'
 import AutoMatchDialog from './AutoMatchDialog'
 import { DEFAULT_ENCODER_MODEL } from './rerankerModels'
-import { normalizeAlgorithmInvocation, lookupStatusRank, normalizeLegacyAllCandidates, filterPropertyBySummary } from './normalizers'
+import { normalizeAlgorithmInvocation, lookupStatusRank, normalizeLegacyAllCandidates, buildRecommendableConceptEntry } from './normalizers'
 import { parseConceptKey } from './conceptKey'
 import { buildQualityRowViews, conceptForMapping, resolveAICandidateID } from './viewBuilders.js'
 
@@ -3792,21 +3792,9 @@ const MapProject = () => {
               e.via = {bridge_concept_key: c.bridge_concept_key, map_type: c.map_type}
             return e
           })
-        const entry = {
-          concept_key: key,
-          canonical_reference: def.reference,
-          ocl_url: def.ocl_url,
-          display_name: def.display_name,
-          names: def.names,
-          descriptions: def.descriptions,
-          concept_class: def.concept_class,
-          datatype: def.datatype,
-          property: filterPropertyBySummary(def.property, summaryPropertyCodes),
-          rerank_score: rowState?.concept_rows?.[key]?.rerank_score,
-          evidence
-        }
-        if(def.retired === true) entry.retired = true
-        recommendable_concepts.push(entry)
+        recommendable_concepts.push(buildRecommendableConceptEntry({
+          def, key, evidence, rowState, summaryPropertyCodes
+        }))
       }
       // Else: concept from a non-target, non-bridge source — skip
     })

--- a/src/components/map-projects/MapProject.jsx
+++ b/src/components/map-projects/MapProject.jsx
@@ -98,7 +98,7 @@ import ProjectLogs from './ProjectLogs';
 import { useAlgos, CONCEPT_IDENTITY_BY_TYPE, ensureConceptIdentity } from './algorithms'
 import AutoMatchDialog from './AutoMatchDialog'
 import { DEFAULT_ENCODER_MODEL } from './rerankerModels'
-import { normalizeAlgorithmInvocation, lookupStatusRank, normalizeLegacyAllCandidates } from './normalizers'
+import { normalizeAlgorithmInvocation, lookupStatusRank, normalizeLegacyAllCandidates, filterPropertyBySummary } from './normalizers'
 import { parseConceptKey } from './conceptKey'
 import { buildQualityRowViews, conceptForMapping, resolveAICandidateID } from './viewBuilders.js'
 
@@ -3750,6 +3750,10 @@ const MapProject = () => {
     }
 
     const targetCanonical = projectContext.target_repo.canonical_url
+    // Project-pinned identifying property codes. When absent (FHIR-passthrough
+    // sources or repos that haven't pinned a summary), filterPropertyBySummary
+    // passes def.property through whole.
+    const summaryPropertyCodes = repoVersion?.meta?.display?.concept_summary_properties
     const recommendable_concepts = []
     const bridge_context = []
 
@@ -3788,7 +3792,7 @@ const MapProject = () => {
               e.via = {bridge_concept_key: c.bridge_concept_key, map_type: c.map_type}
             return e
           })
-        recommendable_concepts.push({
+        const entry = {
           concept_key: key,
           canonical_reference: def.reference,
           ocl_url: def.ocl_url,
@@ -3797,9 +3801,12 @@ const MapProject = () => {
           descriptions: def.descriptions,
           concept_class: def.concept_class,
           datatype: def.datatype,
-          properties: def.properties,
+          property: filterPropertyBySummary(def.property, summaryPropertyCodes),
+          rerank_score: rowState?.concept_rows?.[key]?.rerank_score,
           evidence
-        })
+        }
+        if(def.retired === true) entry.retired = true
+        recommendable_concepts.push(entry)
       }
       // Else: concept from a non-target, non-bridge source — skip
     })
@@ -3823,33 +3830,14 @@ const MapProject = () => {
       console.error('AI ASSISTANT is not enabled for you.')
       return false
     }
-    // Source the legacy `candidates[]` array first from allCandidates (the
-    // PR2a path), and fall back to projecting from the unified rowMatchState
-    // when legacy is empty. Without the fallback, any flow that ends with
-    // populated rowMatchState but empty allCandidates (e.g. flag-on saved-
-    // project load races, or future paths that skip the parallel legacy
-    // write) bails before the POST fires — user sees no AI Assistant
-    // response even though the row clearly has candidates on screen.
-    let _candidates = flatten(map(selectedAlgoIds, algoId => find(allCandidatesRef.current[algoId], c => c.row?.__index === __index)?.results || []))
-    if(_candidates.length === 0 && rowMatchStateRef.current?.[__index]) {
-      const rowState = rowMatchStateRef.current[__index]
-      _candidates = compact(
-        Object.values(rowState.candidates || {}).map(cand => {
-          const def = conceptCacheRef.current[cand.concept_key]
-          if(!def) return null
-          const conceptRow = rowState.concept_rows?.[cand.concept_key]
-          const bridgeDef = cand.bridge_concept_key ? conceptCacheRef.current[cand.bridge_concept_key] : undefined
-          return conceptForMapping({candidate: cand, conceptDefinition: def, conceptRow, bridgeConceptDefinition: bridgeDef})
-        })
-      )
-    }
     // Auto-match (caller supplied resolvedPromptTemplate) fires once per row;
     // user-initiated single-row clicks always append a new entry to the
     // per-row analysis history.
     const isAutoMatch = Boolean(resolvedPromptTemplate)
     const existingAnalyses = analysis[__index] || []
     const alreadyAnalyzed = isAutoMatch && existingAnalyses.length > 0
-    if(isNumber(__index) && repoVersion && !alreadyAnalyzed && _candidates?.length > 0) {
+    const v2 = isNumber(__index) ? buildV2RecommendationPayload(__index) : null
+    if(isNumber(__index) && repoVersion && !alreadyAnalyzed && (v2?.recommendable_concepts?.length || 0) > 0) {
       if(!promptTemplate?.key) {
         setAlert({message: 'AI Assistant prompt template is not available', severity: 'error'})
         markAlgo(__index, 'recommend', -3)
@@ -3858,12 +3846,6 @@ const MapProject = () => {
 
       markAlgo(__index, 'recommend', 0)
       let rowData = prepareRow(__row, true, true)
-      // Option A: additive. Keep the legacy `candidates` field for the
-      // current prompt template; spread v2 fields alongside for the next
-      // prompt-template revision (which will read recommendable_concepts +
-      // bridge_context and structurally exclude bridges from the
-      // recommendation pool, fixing the bridge-recommendation bug).
-      const v2 = buildV2RecommendationPayload(__index)
 
       const selectedModel = getSelectedAIModel()
       let activePromptTemplate
@@ -3897,33 +3879,14 @@ const MapProject = () => {
         return false
       }
       const promptTemplateRef = getPromptTemplateRef(activePromptTemplate)
-      // Strip heavy fields before sending to the LLM. These are useful for
-      // the in-app UI (Table view chips, hover details) but burn tokens
-      // without adding signal for matching judgments. Keep the things the
-      // legacy prompt template actually reads (id, display_name, source,
-      // search_meta, url, concept_class, datatype, retired, mappings,
-      // property), drop the bulky ones.
-      //   extras       - LOINC source-specific JSON; very large per concept
-      //   names        - multiple locales, redundant with display_name
-      //   descriptions - multiple, often long; not used for matching
-      // The v2 `recommendable_concepts` already omits these (see
-      // buildV2RecommendationPayload). NB: if you see a literal "max_tokens"
-      // error from the model, that's the server-side prompt template's
-      // output budget — check ocl-ai-assistant's template config, not this
-      // file.
-      const stripHeavyFields = (c) => omit(c, ['_source', 'extras', 'names', 'descriptions'])
       const payload = {
         variables: {
           project: getProjectMetadata(),
           row: rowData.row,
           metadata: rowData.metadata,
-          candidates: [..._candidates.map(stripHeavyFields)],
-          ...(v2 ? {
-            payload_version: 'v2',
-            target_repo: v2.target_repo,
-            recommendable_concepts: v2.recommendable_concepts,
-            bridge_context: v2.bridge_context
-          } : {})
+          target_repo: v2.target_repo,
+          recommendable_concepts: v2.recommendable_concepts,
+          bridge_context: v2.bridge_context
         }
       }
 

--- a/src/components/map-projects/__tests__/normalizers.test.js
+++ b/src/components/map-projects/__tests__/normalizers.test.js
@@ -18,7 +18,8 @@ import assert from 'node:assert/strict'
 import {
   createAlgorithmResponse,
   normalizeAlgoResult,
-  normalizeAlgorithmInvocation
+  normalizeAlgorithmInvocation,
+  filterPropertyBySummary
 } from '../normalizers.js'
 import { makeConceptKey, parseConceptKey, referencesEqual } from '../conceptKey.js'
 
@@ -900,4 +901,68 @@ test('fixed-canonical algo with no target_repo.version on project (unpinned) sti
   assert.ok(def)
   assert.equal(def.reference.version, undefined)
   assert.deepEqual(def.reference, { url: 'http://loinc.org', code: '49494-3' })
+})
+
+// ============================================================================
+// filterPropertyBySummary — producer-side property filter for AI Assistant
+// v2 payload. See unified-mapper-model.md (PR3-D1).
+// ============================================================================
+
+// Realistic LOINC property dict (subset). OCL emits this as an array of
+// {code, value} pairs from ConceptDetailSerializer.property.
+const loincProperty = [
+  { code: 'COMPONENT', value: 'Glucose' },
+  { code: 'PROPERTY', value: 'MCnc' },
+  { code: 'TIME_ASPCT', value: 'Pt' },
+  { code: 'SYSTEM', value: 'Ser/Plas' },
+  { code: 'SCALE_TYP', value: 'Qn' },
+  { code: 'METHOD', value: '' },
+  { code: 'CLASS', value: 'CHEM' },
+  { code: 'STATUS', value: 'ACTIVE' },
+  { code: 'VersionLastChanged', value: '2.74' }
+]
+
+test('filterPropertyBySummary: passes property through when no summary codes configured', () => {
+  assert.equal(filterPropertyBySummary(loincProperty, undefined), loincProperty)
+  assert.equal(filterPropertyBySummary(loincProperty, null), loincProperty)
+  assert.equal(filterPropertyBySummary(loincProperty, []), loincProperty)
+})
+
+test('filterPropertyBySummary: filters to the summary subset when configured', () => {
+  const summary = ['COMPONENT', 'PROPERTY', 'TIME_ASPCT', 'SYSTEM', 'SCALE_TYP', 'METHOD']
+  const out = filterPropertyBySummary(loincProperty, summary)
+  assert.equal(out.length, 6)
+  assert.deepEqual(out.map(p => p.code).sort(),
+    ['COMPONENT', 'METHOD', 'PROPERTY', 'SCALE_TYP', 'SYSTEM', 'TIME_ASPCT'])
+  // Identity-bearing chips are kept; bookkeeping fields (CLASS / STATUS /
+  // VersionLastChanged) are dropped from the v2 prompt push.
+  assert.ok(!out.some(p => p.code === 'CLASS'))
+  assert.ok(!out.some(p => p.code === 'STATUS'))
+})
+
+test('filterPropertyBySummary: returns undefined when property is missing/empty', () => {
+  assert.equal(filterPropertyBySummary(undefined, ['COMPONENT']), undefined)
+  assert.equal(filterPropertyBySummary(null, ['COMPONENT']), undefined)
+  assert.equal(filterPropertyBySummary([], ['COMPONENT']), undefined)
+})
+
+test('filterPropertyBySummary: filtered result drops entries whose code is not in the summary', () => {
+  const summary = ['COMPONENT', 'SYSTEM']
+  const out = filterPropertyBySummary(loincProperty, summary)
+  assert.deepEqual(out, [
+    { code: 'COMPONENT', value: 'Glucose' },
+    { code: 'SYSTEM', value: 'Ser/Plas' }
+  ])
+})
+
+test('filterPropertyBySummary: tolerates entries without a code field', () => {
+  const property = [
+    { code: 'COMPONENT', value: 'Glucose' },
+    { value: 'orphan' },
+    { code: undefined, value: 'still orphan' },
+    { code: 'SYSTEM', value: 'Ser/Plas' }
+  ]
+  const out = filterPropertyBySummary(property, ['COMPONENT', 'SYSTEM'])
+  assert.equal(out.length, 2)
+  assert.deepEqual(out.map(p => p.code), ['COMPONENT', 'SYSTEM'])
 })

--- a/src/components/map-projects/__tests__/normalizers.test.js
+++ b/src/components/map-projects/__tests__/normalizers.test.js
@@ -19,7 +19,8 @@ import {
   createAlgorithmResponse,
   normalizeAlgoResult,
   normalizeAlgorithmInvocation,
-  filterPropertyBySummary
+  filterPropertyBySummary,
+  buildRecommendableConceptEntry
 } from '../normalizers.js'
 import { makeConceptKey, parseConceptKey, referencesEqual } from '../conceptKey.js'
 
@@ -908,18 +909,30 @@ test('fixed-canonical algo with no target_repo.version on project (unpinned) sti
 // v2 payload. See unified-mapper-model.md (PR3-D1).
 // ============================================================================
 
-// Realistic LOINC property dict (subset). OCL emits this as an array of
-// {code, value} pairs from ConceptDetailSerializer.property.
+// LOINC concept 2345-7 (Glucose [Mass/volume] in Serum or Plasma) property
+// dict. Shape matches GET /orgs/Regenstrief/sources/LOINC/concepts/2345-7/
+// on prod (verified 2026-05-14): array of {code, valueCoding} pairs from
+// ConceptDetailSerializer.property = JSONField(source='properties').
 const loincProperty = [
-  { code: 'COMPONENT', value: 'Glucose' },
-  { code: 'PROPERTY', value: 'MCnc' },
-  { code: 'TIME_ASPCT', value: 'Pt' },
-  { code: 'SYSTEM', value: 'Ser/Plas' },
-  { code: 'SCALE_TYP', value: 'Qn' },
-  { code: 'METHOD', value: '' },
-  { code: 'CLASS', value: 'CHEM' },
-  { code: 'STATUS', value: 'ACTIVE' },
-  { code: 'VersionLastChanged', value: '2.74' }
+  { code: 'COMPONENT', valueCoding: 'Glucose' },
+  { code: 'PROPERTY', valueCoding: 'MCnc' },
+  { code: 'TIME_ASPCT', valueCoding: 'Pt' },
+  { code: 'SYSTEM', valueCoding: 'Ser/Plas' },
+  { code: 'SCALE_TYP', valueCoding: 'Qn' },
+  { code: 'METHOD_TYP', valueCoding: '' },
+  { code: 'CLASS', valueCoding: 'CHEM' },
+  { code: 'STATUS', valueCoding: 'ACTIVE' },
+  { code: 'VersionLastChanged', valueCoding: '2.74' }
+]
+
+// Real production concept_summary_properties pinned on the LOINC repo
+// (https://api.openconceptlab.org/orgs/Regenstrief/sources/LOINC/, verified
+// 2026-05-14). Drops VersionLastChanged + STATUS; includes EXAMPLE_UCUM_UNITS /
+// ORDER_OBS / COMMON_TEST_RANK which the test fixture above doesn't carry —
+// representative of real filter behavior: matched-codes-only.
+const loincSummaryProperties = [
+  'COMPONENT', 'PROPERTY', 'TIME_ASPCT', 'SYSTEM', 'SCALE_TYP', 'METHOD_TYP',
+  'CLASS', 'EXAMPLE_UCUM_UNITS', 'ORDER_OBS', 'COMMON_TEST_RANK'
 ]
 
 test('filterPropertyBySummary: passes property through when no summary codes configured', () => {
@@ -928,16 +941,17 @@ test('filterPropertyBySummary: passes property through when no summary codes con
   assert.equal(filterPropertyBySummary(loincProperty, []), loincProperty)
 })
 
-test('filterPropertyBySummary: filters to the summary subset when configured', () => {
-  const summary = ['COMPONENT', 'PROPERTY', 'TIME_ASPCT', 'SYSTEM', 'SCALE_TYP', 'METHOD']
-  const out = filterPropertyBySummary(loincProperty, summary)
-  assert.equal(out.length, 6)
+test('filterPropertyBySummary: filters to the summary subset (real LOINC summary pins)', () => {
+  const out = filterPropertyBySummary(loincProperty, loincSummaryProperties)
+  // 7 of the 9 fixture entries are in the summary (the other 3 summary codes
+  // — EXAMPLE_UCUM_UNITS, ORDER_OBS, COMMON_TEST_RANK — aren't in the fixture).
+  assert.equal(out.length, 7)
   assert.deepEqual(out.map(p => p.code).sort(),
-    ['COMPONENT', 'METHOD', 'PROPERTY', 'SCALE_TYP', 'SYSTEM', 'TIME_ASPCT'])
-  // Identity-bearing chips are kept; bookkeeping fields (CLASS / STATUS /
-  // VersionLastChanged) are dropped from the v2 prompt push.
-  assert.ok(!out.some(p => p.code === 'CLASS'))
+    ['CLASS', 'COMPONENT', 'METHOD_TYP', 'PROPERTY', 'SCALE_TYP', 'SYSTEM', 'TIME_ASPCT'])
+  // Bookkeeping fields (STATUS, VersionLastChanged) are dropped — they
+  // aren't in the LOINC repo's summary pin.
   assert.ok(!out.some(p => p.code === 'STATUS'))
+  assert.ok(!out.some(p => p.code === 'VersionLastChanged'))
 })
 
 test('filterPropertyBySummary: returns undefined when property is missing/empty', () => {
@@ -947,22 +961,162 @@ test('filterPropertyBySummary: returns undefined when property is missing/empty'
 })
 
 test('filterPropertyBySummary: filtered result drops entries whose code is not in the summary', () => {
-  const summary = ['COMPONENT', 'SYSTEM']
-  const out = filterPropertyBySummary(loincProperty, summary)
+  const out = filterPropertyBySummary(loincProperty, ['COMPONENT', 'SYSTEM'])
   assert.deepEqual(out, [
-    { code: 'COMPONENT', value: 'Glucose' },
-    { code: 'SYSTEM', value: 'Ser/Plas' }
+    { code: 'COMPONENT', valueCoding: 'Glucose' },
+    { code: 'SYSTEM', valueCoding: 'Ser/Plas' }
   ])
 })
 
 test('filterPropertyBySummary: tolerates entries without a code field', () => {
   const property = [
-    { code: 'COMPONENT', value: 'Glucose' },
-    { value: 'orphan' },
-    { code: undefined, value: 'still orphan' },
-    { code: 'SYSTEM', value: 'Ser/Plas' }
+    { code: 'COMPONENT', valueCoding: 'Glucose' },
+    { valueCoding: 'orphan' },
+    { code: undefined, valueCoding: 'still orphan' },
+    { code: 'SYSTEM', valueCoding: 'Ser/Plas' }
   ]
   const out = filterPropertyBySummary(property, ['COMPONENT', 'SYSTEM'])
   assert.equal(out.length, 2)
   assert.deepEqual(out.map(p => p.code), ['COMPONENT', 'SYSTEM'])
+})
+
+// ============================================================================
+// buildRecommendableConceptEntry — per-concept push into recommendable_concepts.
+// Exercises the 3 PR3-D1 producer additions: property (filtered by summary),
+// rerank_score (from rowState), retired (truthy-only).
+// ============================================================================
+
+// LOINC ConceptDefinition fixture matching the shape produced by
+// toConceptDefinition (normalizers.js) for LOINC 2345-7.
+const loincDef = {
+  reference: { url: 'http://loinc.org', code: '2345-7', version: '2.74' },
+  key: 'http://loinc.org|2345-7|2.74',
+  ocl_url: '/orgs/Regenstrief/sources/LOINC/concepts/2345-7/',
+  id: '2345-7',
+  display_name: 'Glucose [Mass/volume] in Serum or Plasma',
+  source: 'LOINC',
+  owner: 'Regenstrief',
+  names: [{ name: 'Glucose [Mass/volume] in Serum or Plasma', locale: 'en', locale_preferred: true }],
+  descriptions: [],
+  concept_class: 'LP',
+  datatype: 'Qn',
+  retired: false,
+  property: loincProperty,
+  lookup_status: 'full',
+  lookup_source_type: 'algorithm',
+  lookup_source: 'ocl-search'
+}
+
+const stdEvidence = [
+  { algorithm_id: 'ocl-search', candidate_type: 'standard', score: 0.93, highlights: ['glucose'] }
+]
+
+test('buildRecommendableConceptEntry: standard target-repo concept — all 3 PR3-D1 fields wired correctly', () => {
+  const rowState = {
+    concept_rows: { 'http://loinc.org|2345-7|2.74': { rerank_score: 0.87 } }
+  }
+  const entry = buildRecommendableConceptEntry({
+    def: loincDef,
+    key: loincDef.key,
+    evidence: stdEvidence,
+    rowState,
+    summaryPropertyCodes: loincSummaryProperties
+  })
+
+  // Identity + display passthrough
+  assert.equal(entry.concept_key, loincDef.key)
+  assert.deepEqual(entry.canonical_reference, loincDef.reference)
+  assert.equal(entry.ocl_url, loincDef.ocl_url)
+  assert.equal(entry.display_name, loincDef.display_name)
+  assert.equal(entry.concept_class, 'LP')
+  assert.equal(entry.datatype, 'Qn')
+
+  // (1) property is the filtered subset — 7 entries match the real-prod
+  //     LOINC summary pin from the fixture.
+  assert.ok(Array.isArray(entry.property))
+  assert.equal(entry.property.length, 7)
+  assert.deepEqual(entry.property.map(p => p.code).sort(),
+    ['CLASS', 'COMPONENT', 'METHOD_TYP', 'PROPERTY', 'SCALE_TYP', 'SYSTEM', 'TIME_ASPCT'])
+  assert.ok(!entry.property.some(p => p.code === 'STATUS'))
+  assert.ok(!entry.property.some(p => p.code === 'VersionLastChanged'))
+
+  // (2) rerank_score wired from rowState
+  assert.equal(entry.rerank_score, 0.87)
+
+  // (3) retired is absent (def.retired === false → not emitted)
+  assert.equal('retired' in entry, false)
+
+  assert.deepEqual(entry.evidence, stdEvidence)
+})
+
+test('buildRecommendableConceptEntry: retired:true on def emits retired:true on entry', () => {
+  const entry = buildRecommendableConceptEntry({
+    def: { ...loincDef, retired: true },
+    key: loincDef.key,
+    evidence: stdEvidence,
+    rowState: undefined,
+    summaryPropertyCodes: loincSummaryProperties
+  })
+  assert.equal(entry.retired, true)
+})
+
+test('buildRecommendableConceptEntry: retired absent for def.retired === false / undefined / "true" (truthy-string)', () => {
+  for (const retired of [false, undefined, null, 0, '', 'true']) {
+    const entry = buildRecommendableConceptEntry({
+      def: { ...loincDef, retired },
+      key: loincDef.key,
+      evidence: stdEvidence,
+      rowState: undefined,
+      summaryPropertyCodes: undefined
+    })
+    assert.equal('retired' in entry, false,
+      `retired=${JSON.stringify(retired)} should produce entry WITHOUT retired key`)
+  }
+})
+
+test('buildRecommendableConceptEntry: rerank_score is undefined when rowState is empty or concept_key absent', () => {
+  const entryNoRowState = buildRecommendableConceptEntry({
+    def: loincDef, key: loincDef.key, evidence: stdEvidence,
+    rowState: undefined, summaryPropertyCodes: undefined
+  })
+  assert.equal(entryNoRowState.rerank_score, undefined)
+
+  const entryDifferentKey = buildRecommendableConceptEntry({
+    def: loincDef, key: loincDef.key, evidence: stdEvidence,
+    rowState: { concept_rows: { 'http://loinc.org|99999-9|2.74': { rerank_score: 0.5 } } },
+    summaryPropertyCodes: undefined
+  })
+  assert.equal(entryDifferentKey.rerank_score, undefined)
+})
+
+test('buildRecommendableConceptEntry: property passes through whole when summary codes are not pinned', () => {
+  const entry = buildRecommendableConceptEntry({
+    def: loincDef, key: loincDef.key, evidence: stdEvidence,
+    rowState: undefined, summaryPropertyCodes: undefined
+  })
+  // No filter applied — full 9-entry fixture passes through.
+  assert.equal(entry.property.length, 9)
+})
+
+test('buildRecommendableConceptEntry: property is undefined when def has no property data', () => {
+  const entry = buildRecommendableConceptEntry({
+    def: { ...loincDef, property: undefined }, key: loincDef.key, evidence: stdEvidence,
+    rowState: undefined, summaryPropertyCodes: loincSummaryProperties
+  })
+  assert.equal(entry.property, undefined)
+})
+
+test('buildRecommendableConceptEntry: bridge_child evidence carries via.bridge_concept_key into entry untouched', () => {
+  const bridgeEvidence = [
+    { algorithm_id: 'ocl-ciel-bridge', candidate_type: 'bridge_child', score: 0.88,
+      highlights: undefined,
+      via: { bridge_concept_key: 'https://CIELterminology.org|887|2024-01', map_type: 'SAME-AS' } }
+  ]
+  const entry = buildRecommendableConceptEntry({
+    def: loincDef, key: loincDef.key, evidence: bridgeEvidence,
+    rowState: { concept_rows: { [loincDef.key]: { rerank_score: 0.91 } } },
+    summaryPropertyCodes: loincSummaryProperties
+  })
+  assert.deepEqual(entry.evidence, bridgeEvidence)
+  assert.equal(entry.rerank_score, 0.91)
 })

--- a/src/components/map-projects/constants.jsx
+++ b/src/components/map-projects/constants.jsx
@@ -72,4 +72,4 @@ export const ROW_STAGES = {
   '0': 'in_progress',
   '1': 'completed'
 }
-export const PROMPTS_KEY_DEFAULT = 'match-recommend'
+export const PROMPTS_KEY_DEFAULT = 'match-recommend-normalized'

--- a/src/components/map-projects/normalizers.js
+++ b/src/components/map-projects/normalizers.js
@@ -379,6 +379,28 @@ const LOOKUP_RANK = { pending: 0, failed: 0, partial: 1, full: 2 }
 export const lookupStatusRank = (status) => LOOKUP_RANK[status] ?? 0
 
 /**
+ * Filter a ConceptDefinition.property[] dict array to the subset the project
+ * considers identifying — repoVersion.meta.display.concept_summary_properties
+ * (e.g. for LOINC: COMPONENT / PROPERTY / TIME_ASPCT / SYSTEM / SCALE_TYP /
+ * METHOD). Producer-side volume control for the AI Assistant v2 payload's
+ * recommendable_concepts[*].property push.
+ *
+ * Returns:
+ *   - undefined  when `property` is missing/empty (essentializer drops the key)
+ *   - `property` whole when no summary list is configured (FHIR-passthrough
+ *     sources, or repos that haven't pinned summary properties)
+ *   - filtered subset matching the summary codes otherwise
+ *
+ * Pure: no lodash, no React.
+ */
+export const filterPropertyBySummary = (property, summaryCodes) => {
+  if (!Array.isArray(property) || property.length === 0) return undefined
+  if (!Array.isArray(summaryCodes) || summaryCodes.length === 0) return property
+  const set = new Set(summaryCodes)
+  return property.filter(p => p?.code && set.has(p.code))
+}
+
+/**
  * Backfill rowMatchState + ConceptDefinitions from the legacy
  * `allCandidates` shape (a saved-project artifact: `{ [algoId]: [{row,
  * results}, ...] }`). Called on project load so that v1-saved projects

--- a/src/components/map-projects/normalizers.js
+++ b/src/components/map-projects/normalizers.js
@@ -401,6 +401,37 @@ export const filterPropertyBySummary = (property, summaryCodes) => {
 }
 
 /**
+ * Build a single recommendable_concepts[*] entry for the AI Assistant v2
+ * payload. Pure projection — no React, no refs. The MapProject component
+ * calls this once per (target-canonical) ConceptDefinition while walking
+ * defsByKey in buildV2RecommendationPayload.
+ *
+ * @param {Object} args
+ * @param {Object} args.def                  ConceptDefinition (from conceptCache or normalizer output)
+ * @param {string} args.key                  the concept_key
+ * @param {Array<Object>} args.evidence      [{algorithm_id, candidate_type, score, highlights, via?}, ...]
+ * @param {Object} [args.rowState]           rowMatchState[rowIndex] — provides rerank_score per concept_key
+ * @param {Array<string>} [args.summaryPropertyCodes] target_repo summary property codes (optional filter)
+ */
+export const buildRecommendableConceptEntry = ({ def, key, evidence, rowState, summaryPropertyCodes }) => {
+  const entry = {
+    concept_key: key,
+    canonical_reference: def.reference,
+    ocl_url: def.ocl_url,
+    display_name: def.display_name,
+    names: def.names,
+    descriptions: def.descriptions,
+    concept_class: def.concept_class,
+    datatype: def.datatype,
+    property: filterPropertyBySummary(def.property, summaryPropertyCodes),
+    rerank_score: rowState?.concept_rows?.[key]?.rerank_score,
+    evidence
+  }
+  if (def.retired === true) entry.retired = true
+  return entry
+}
+
+/**
  * Backfill rowMatchState + ConceptDefinitions from the legacy
  * `allCandidates` shape (a saved-project artifact: `{ [algoId]: [{row,
  * results}, ...] }`). Called on project load so that v1-saved projects


### PR DESCRIPTION
closes OpenConceptLab/ocl_issues#2523
Umbrella: OpenConceptLab/ocl_issues#2337
Pairs with server-side OpenConceptLab/ocl-ai-assistant#143 (merged 2026-05-14)
Spec: [unified-mapper-model.md → PR3-D1](https://github.com/OpenConceptLab/ocl-online-docs/blob/main/mapper/unified-mapper-model.md#pr3-d1--urgent-critical-path-payload-fix--default-flip)

## Summary

Producer-side half of **PR3-D1**. Brings the AI Assistant v2 payload off the additive (Option A) transition shape and onto the normalized template by default.

- **`buildV2RecommendationPayload`** — per-concept push extended with:
  - `property` (FHIR-aligned singular) filtered by `repoVersion.meta.display.concept_summary_properties` when configured; whole-passthrough when undefined (e.g. FHIR-passthrough sources).
  - `rerank_score` from `rowState.concept_rows[key].rerank_score` — the per-(row, concept) unified score.
  - `retired: true` emitted truthy-only.
- **`fetchRecommendation`** — drops legacy `candidates: [..._candidates.map(stripHeavyFields)]`, `payload_version: 'v2'`, the `stripHeavyFields` helper, and the `_candidates` flatten/projection plumbing. The active normalized template's `{% if candidates %}` / `{% if payload_version %}` blocks become inert (both keys are optional in the template — confirmed via REST API).
- **`PROMPTS_KEY_DEFAULT`** — flipped from `'match-recommend'` to `'match-recommend-normalized'`. Existing per-project pins (`-loinc`, `-icd11`) keep working unchanged.
- **`filterPropertyBySummary`** — new pure helper in `normalizers.js`, exported, with 5 node:test cases.

## Why now

This closes out the AI Assistant cost regression diagnosed 2026-05-14: $0.03 → $0.16/exec, plus 42/200 prompt-too-long failures on the top-200 LOINC eval. Without this PR, the producer is still shipping the legacy `candidates[]` array alongside `recommendable_concepts[]` (Option A additive), which doubled tokens. The server-side allow-list rename also won't take effect until the producer renames `properties` → `property` in the payload.

## Minor scope deviations (flagged in commit body too)

- **Summary properties field name** — spec said `target_repo.meta.display.summary_properties`; production data uses `concept_summary_properties` under `repoVersion.meta.display` (per [ConceptSummaryProperties.jsx:14](src/components/concepts/ConceptSummaryProperties.jsx#L14), [Candidates.jsx:356](src/components/map-projects/Candidates.jsx#L356)). Matched production.
- **Stricter AI-fire guard** — switched from `_candidates?.length > 0` to `(v2?.recommendable_concepts?.length || 0) > 0`. The new template requires `target_repo` + `recommendable_concepts`, so this is correctness-first. Cascade-target stubs (always populated by `cascadeTargetToConceptDefinition`) keep the bridge path working.
- **PROMPTS_KEY_DEFAULT** flipped to the bare `'match-recommend-normalized'` key, not the per-target variant. Repo-dispatch (auto-select `-loinc` / `-icd11`) is a possible follow-up but not load-bearing — per-project pins continue to take precedence.

## Test plan

- [x] `npm test` — 96/96 passing locally (5 new tests on `filterPropertyBySummary`)
- [x] `npm run eslint` — clean
- [ ] Staging invoke against a LOINC project (~5 rows including bridge fan-out):
  - `rendered_messages` no longer contains `## Legacy candidates` block content
  - `rendered_messages` contains `"property":` entries inside `recommendable_concepts[]` with LOINC schema fields
  - `tokens_prompt` drops back toward pre-PR2b baseline; `cost_estimate` drops to ~$0.03/exec range
- [ ] Errbit watch — re-run top-200 eval; 42 \"prompt too long\" failures drop to ≤2
- [ ] Manual LOINC e2e walkthrough — LLM's `rationale` cites `COMPONENT` / `SYSTEM` / `SCALE_TYP` / `METHOD`

## Out of scope

- Locale-filter `names[]` + `descriptions[]` — **PR3-H** (next, small surgical change)
- Response-side cleanup (shorten `resolveAICandidateID`, nest `metadata` under `row`, drop `project.target_repo` duplication) — **PR3-D2**
- Retire legacy `match-recommend*` templates from the oclmap selector — **PR3-F**

🤖 Generated with [Claude Code](https://claude.com/claude-code)