### PR TITLE
Rename v2 payload field via.map_type → via.bridge_map_type (ocl_online#107)

### DIFF
--- a/src/components/map-projects/MapProject.jsx
+++ b/src/components/map-projects/MapProject.jsx
@@ -4006,7 +4006,7 @@ const MapProject = () => {
               highlights: c.highlights
             }
             if(c.type === 'bridge_child' && c.bridge_concept_key)
-              e.via = {bridge_concept_key: c.bridge_concept_key, map_type: c.map_type}
+              e.via = {bridge_concept_key: c.bridge_concept_key, bridge_map_type: c.map_type}
             return e
           })
         recommendable_concepts.push(buildRecommendableConceptEntry({

--- a/src/components/map-projects/__tests__/normalizers.test.js
+++ b/src/components/map-projects/__tests__/normalizers.test.js
@@ -1126,7 +1126,7 @@ test('buildRecommendableConceptEntry: bridge_child evidence carries via.bridge_c
   const bridgeEvidence = [
     { algorithm_id: 'ocl-ciel-bridge', candidate_type: 'bridge_child', score: 0.88,
       highlights: undefined,
-      via: { bridge_concept_key: 'https://CIELterminology.org|887|2024-01', map_type: 'SAME-AS' } }
+      via: { bridge_concept_key: 'https://CIELterminology.org|887|2024-01', bridge_map_type: 'SAME-AS' } }
   ]
   const entry = buildRecommendableConceptEntry({
     def: loincDef, key: loincDef.key, evidence: bridgeEvidence,


### PR DESCRIPTION
> ⚠️ **Deploy step 3 of 4.** See coordination checklist in [`ocl_online#107`](https://github.com/OpenConceptLab/ocl_online/issues/107). **Do not merge until step 2 (production `output_schema` PATCH) has been applied** — otherwise the LLM's echoed evidence shape won't match the live output_schema for a window.

## Summary

Renames the bridge-evidence field in the v2 AI Assistant payload from `via.map_type` to `via.bridge_map_type`. One-line change in `MapProject.jsx:4009` plus one test fixture.

## Why

The field lives at `recommendable_concepts[].evidence[].via.map_type` — three levels deep. When flattened (DataFrames, JSONPath queries, log lines) the parent context disappears and "map_type" doesn't say what it's the map_type *of*. The new name:
- Self-describes the field (it's the bridge mapping's relationship type)
- Aligns with the sibling `via.bridge_concept_key` (already prefixed)
- Aligns with the existing `Candidate.bridge_map_type` field in `termwork/ocl-mapper-eval/pipeline/run_judge.py:198` (same concept, different source)

Surfaced during a recent mapper-eval Phase 2A audit where four rounds of code-tracing were required to confirm `map_type` was even in the AI payload — it was, but the field name didn't betray its presence in flat/grep contexts.

## Scope

- `src/components/map-projects/MapProject.jsx:4009` — single LOC change in `buildV2RecommendationPayload`'s evidence builder
- `src/components/map-projects/__tests__/normalizers.test.js:1129` — test fixture updated to reflect the new outgoing shape

**Internal data model unchanged.** The in-memory candidate's `map_type` field (sourced from `mapping.map_type` in `normalizers.js:296`) stays as `map_type` — only the outbound payload key name flips.

## Tests

```
ℹ tests 140
ℹ pass 140
ℹ fail 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)