### PR TITLE
PR3-D2a: drop v1 concept_id/id fallbacks in AI response handling

### DIFF
--- a/src/components/map-projects/AICandidatesAnalysis.jsx
+++ b/src/components/map-projects/AICandidatesAnalysis.jsx
@@ -44,8 +44,7 @@ const AICandidatesAnalysis = ({ analysis: analysisProp, onClose, sx, isCoreUser,
 
   const getAlternateIds = () => {
     const alternates = output?.alternative_candidates || []
-    // v2 response prefers canonical_reference.code; legacy shape used concept_id/id.
-    return compact(map(alternates, a => a?.canonical_reference?.code || a?.concept_id || a?.id)).join(', ')
+    return compact(map(alternates, a => a?.canonical_reference?.code)).join(', ')
   }
 
   return (
@@ -93,7 +92,7 @@ const AICandidatesAnalysis = ({ analysis: analysisProp, onClose, sx, isCoreUser,
                   {t('map_project.primary')}:
                 </Typography>
                 <Typography gutterBottom sx={{ color: 'text.primary', fontSize: 12, mb: 0 }} component='span'>
-                  {output?.primary_candidate?.canonical_reference?.code || output?.primary_candidate?.concept_id || output?.primary_candidate?.id || '-'}
+                  {output?.primary_candidate?.canonical_reference?.code || '-'}
                 </Typography>
               </span>
               <span style={{marginRight: '4px', display: 'inline-flex'}}>

--- a/src/components/map-projects/__tests__/viewHelpers.test.js
+++ b/src/components/map-projects/__tests__/viewHelpers.test.js
@@ -189,26 +189,15 @@ test('resolveAICandidateID: concept_key resolves via conceptCache (preferred)', 
   }
   const candidate = {
     concept_key: 'k1',
-    canonical_reference: { code: 'WRONG' },  // should be ignored when concept_key works
-    concept_id: 'ALSO-WRONG'
+    canonical_reference: { code: 'WRONG' }  // should be ignored when concept_key works
   }
   assert.equal(resolveAICandidateID(candidate, cache), '49494-3')
 })
 
-test('resolveAICandidateID: falls back to canonical_reference.code when concept_key is absent (PR2a shim)', () => {
+test('resolveAICandidateID: falls back to canonical_reference.code when concept_key is absent', () => {
   const cache = {}
-  const candidate = { canonical_reference: { code: '49494-3' }, concept_id: 'LEGACY' }
+  const candidate = { canonical_reference: { code: '49494-3' } }
   assert.equal(resolveAICandidateID(candidate, cache), '49494-3')
-})
-
-test('resolveAICandidateID: falls back to concept_id when v2 fields are absent (legacy v1)', () => {
-  const candidate = { concept_id: '49494-3' }
-  assert.equal(resolveAICandidateID(candidate, {}), '49494-3')
-})
-
-test('resolveAICandidateID: falls back to id when concept_id absent', () => {
-  const candidate = { id: '49494-3' }
-  assert.equal(resolveAICandidateID(candidate, {}), '49494-3')
 })
 
 test('resolveAICandidateID: concept_key present but not in cache falls through to canonical_reference', () => {

--- a/src/components/map-projects/viewBuilders.js
+++ b/src/components/map-projects/viewBuilders.js
@@ -337,12 +337,11 @@ export const getScoreDetails = (input = {}, candidatesScore = {}) => {
  * Resolve an AI Assistant primary_candidate / alternative_candidate to a
  * displayable concept code. Resolution order:
  *   1. concept_key -> conceptCache[key].reference.code (v2, preferred)
- *   2. canonical_reference.code (v2 fallback, PR2a shim)
- *   3. concept_id / id (legacy v1)
+ *   2. canonical_reference.code (v2 fallback)
  */
 export const resolveAICandidateID = (candidate, conceptCache) => {
   if(!candidate) return null
   if(candidate.concept_key && conceptCache?.[candidate.concept_key]?.reference?.code)
     return conceptCache[candidate.concept_key].reference.code
-  return candidate.canonical_reference?.code || candidate.concept_id || candidate.id || null
+  return candidate.canonical_reference?.code || null
 }


### PR DESCRIPTION
## Summary

Closes [OpenConceptLab/ocl_issues#2539](https://github.com/OpenConceptLab/ocl_issues/issues/2539). Companion to [OpenConceptLab/ocl-ai-assistant#170](https://github.com/OpenConceptLab/ocl-ai-assistant/issues/170) (server-side dead-code drop).

Pure dead-code cleanup. Drops the legacy v1 response-shape fallbacks (`concept_id` / `id`) from oclmap's read-side AI Assistant response handling. Net -13 lines.

- **viewBuilders.js** — shorten `resolveAICandidateID` chain to `concept_key -> conceptCache[key].reference.code` then `canonical_reference.code` then `null`.
- **AICandidatesAnalysis.jsx** — drop the same shims from primary + alternate candidate displays.
- **__tests__/viewHelpers.test.js** — drop the 2 tests that exercised the removed v1 paths.

## Why this is safe now

The legacy v1 response shape is unreachable in current production:

- Verified against 5 recent prod prompt-executions (4031, 4030, 4029, 4025, 4020): every response carries `concept_key` + `canonical_reference`; none carry `concept_id` or `id`.
- The legacy `match-recommend` / `match-recommend-loinc` / `match-recommend-loinc-es` templates that produced the v1 shape are deactivated (`is_active=False`) and no longer appear in the oclmap selector.
- The v2 shape has been the only shape in flight since PR2b (2026-05-13).

Worst case: an old saved `analysis` blob from a pre-PR2b project would render `-` for primary/alternate codes in the AI analysis panel. Purely cosmetic; the affected panel is about to be rewritten as part of [#2461](https://github.com/OpenConceptLab/ocl_issues/issues/2461).

## Test plan

- [x] `npm test` — 147/147 passing (5 `resolveAICandidateID` tests retained, 2 v1-path tests removed)
- [x] `npm run eslint` — clean on touched files
- [x] Manual smoke: open an existing project, fire an AI recommendation, confirm primary + alternate codes render in the AICandidatesAnalysis panel
- [x] Manual smoke: export CSV, confirm `__oclai_match_concept__` and `__oclai_alt_concepts__` columns populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)