### PR TITLE
Mapper: align maptype chip with wrapped name + stop properties row overflow (closes #2542)

### DIFF
--- a/src/components/concepts/Property.jsx
+++ b/src/components/concepts/Property.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const Property = ({code, value}) => {
   return (
-    <span className='searchable' style={{marginRight: '6px'}}><i style={{marginRight: '3px', fontSize: '10px'}}>{code}:</i>{value}</span>
+    <span className='searchable' style={{marginRight: '6px', display: 'inline-block', whiteSpace: 'nowrap'}}><i style={{marginRight: '3px', fontSize: '10px'}}>{code}:</i>{value}</span>
   )
 }
 

--- a/src/components/map-projects/Concept.jsx
+++ b/src/components/map-projects/Concept.jsx
@@ -31,7 +31,7 @@ const formatBridgeContributor = (entry) => {
 const MAP_TYPE_CHIP_SX = {
   height: '18px',
   borderRadius: '4px',
-  margin: '0 6px',
+  margin: '0 6px 0 0',
   verticalAlign: 'baseline',
   '.MuiChip-label': {
     padding: '0 6px',
@@ -197,7 +197,8 @@ const Item = ({candidate, conceptDefinition, conceptRow, bridgeConceptDefinition
             }
           </div>
         }
-        sx={{margin: '2px 0', '.MuiListItemText-primary': {fontSize: '14px'}, '.MuiListItemText-secondary': {fontSize: '12px', overflow: 'scroll'}}}
+        slotProps={{secondary: {component: 'div'}}}
+        sx={{margin: '2px 0', '.MuiListItemText-primary': {fontSize: '14px'}, '.MuiListItemText-secondary': {fontSize: '12px'}}}
       />
       <span style={{display: 'flex', alignItems: 'flex-start'}}>
         {


### PR DESCRIPTION
Closes OpenConceptLab/ocl_issues#2542

## Summary
- Drop the chip's left margin so the maptype chip's left border aligns with the wrapped name continuation and the properties row below.
- Render `ListItemText` `secondary` slot as a `<div>` (via `slotProps`) so our `<div>` children stay contained inside it — previously the default `<p>` wrapper auto-closed, ejecting the props row out of the flex column.
- Remove `overflow: scroll` from `.MuiListItemText-secondary` so the properties row wraps instead of horizontal-scrolling.
- Make each `<Property>` `display: inline-block` + `white-space: nowrap` so each property stays atomic (no mid-value breaks like `Hemoglobin` ↓ `pattern`) and the boundaries between properties become real wrap opportunities (no panel overflow).

## Test plan
- [ ] Open a candidate row with bridge children (e.g. `ocl-ciel-bridge`) and verify the `BROADER-THAN` / `SAME-AS` chip's left border sits flush with both the wrapped name continuation and the `COMPONENT:` row.
- [ ] Verify the properties row wraps to a second line within the panel width — no horizontal scrolling of the panel, no clipped trailing properties.
- [ ] Verify multi-word property values (e.g. `COMPONENT: Hemoglobin pattern`) stay on one line; wrap only occurs between properties.
- [ ] Spot-check non-bridge candidate rows for any regression to the same properties row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)