### PR TITLE
Mapper: show orphan-algorithm candidates in the by-algorithm view

### DIFF
--- a/src/components/map-projects/Candidates.jsx
+++ b/src/components/map-projects/Candidates.jsx
@@ -49,6 +49,7 @@ import AICandidatesAnalysis from './AICandidatesAnalysis'
 import AIAssistantButton from './AIAssistantButton'
 import {
   buildAlgorithmRowViews,
+  getOrphanAlgorithmIds,
   buildQualityRowViews,
   conceptBelongsToTargetRepo,
   sortRowViews,
@@ -530,8 +531,22 @@ const Candidates = ({rowIndex, alert, setAlert, rowState, conceptCache, targetCa
         ['hasCandidates', 'algo.order'],
         ['desc', 'asc']
       )
+      // A candidate's algorithm_id can fall outside the project's configured
+      // algorithms[] — the project was reconfigured after running algorithms,
+      // or the PR3-C v1->v2 migration tagged it with an id that isn't current.
+      // These "orphan-algo" candidates already show in the quality view and the
+      // AI payload (both gated by target-repo membership, never by
+      // algorithm_id), but the by-algorithm grouping above only iterates the
+      // configured algos — so they'd appear in no bucket here. Surface one
+      // bucket per orphan id, after all configured algos. Like the configured
+      // buckets, these keep the by-algo "full mix" (no target-repo filter);
+      // per-row mappability stays gated downstream as before.
+      const orphanAlgos = getOrphanAlgorithmIds(rowState, algosSelected.map(a => a.id)).map(id => ({
+        algo: { id, name: t('map_project.unrecognized_algorithm'), order: Infinity },
+        views: buildAlgorithmRowViews(rowState, conceptCache, id)
+      }))
       return {
-        byAlgoCandidates: sortedAlgos.map(({algo, views}) => ({
+        byAlgoCandidates: [...sortedAlgos, ...orphanAlgos].map(({algo, views}) => ({
           algo,
           // Sort the top-level (bridge intermediaries and standard candidates)
           // and, for each bridge, sort its nested cascade targets by the same

--- a/src/components/map-projects/__tests__/views.test.js
+++ b/src/components/map-projects/__tests__/views.test.js
@@ -17,6 +17,7 @@ import assert from 'node:assert/strict'
 
 import {
   buildAlgorithmRowViews,
+  getOrphanAlgorithmIds,
   buildQualityRowViews,
   candidateToRowView,
   conceptForMapping,
@@ -210,6 +211,66 @@ test('buildAlgorithmRowViews skips candidates whose ConceptDefinition is missing
     concept_rows: {}
   }
   assert.deepEqual(buildAlgorithmRowViews(rowState, {}, 'ocl-search'), [])
+})
+
+// ---------- getOrphanAlgorithmIds ----------
+
+test('getOrphanAlgorithmIds returns empty array when rowState is null', () => {
+  assert.deepEqual(getOrphanAlgorithmIds(null, ['ocl-search']), [])
+})
+
+test('getOrphanAlgorithmIds returns distinct candidate algorithm_ids not in the configured set', () => {
+  const rowState = {
+    candidates: {
+      c1: { id: 'c1', algorithm_id: 'ocl-search', concept_key: KEY_LOINC_GLUCOSE, type: 'standard' },
+      c2: { id: 'c2', algorithm_id: 'legacy-fuzzy', concept_key: KEY_LOINC_CHOL, type: 'standard' },
+      c3: { id: 'c3', algorithm_id: 'legacy-fuzzy', concept_key: KEY_LOINC_GLUCOSE, type: 'standard' },
+      c4: { id: 'c4', algorithm_id: 'ocl-bridge', concept_key: KEY_CIEL_BRIDGE, type: 'bridge' }
+    },
+    concept_rows: {}
+  }
+  // ocl-search & ocl-bridge are configured; legacy-fuzzy is the only orphan,
+  // de-duplicated across c2/c3.
+  assert.deepEqual(getOrphanAlgorithmIds(rowState, ['ocl-search', 'ocl-bridge']), ['legacy-fuzzy'])
+})
+
+test('getOrphanAlgorithmIds returns [] when every candidate algorithm_id is configured', () => {
+  const rowState = {
+    candidates: {
+      c1: { id: 'c1', algorithm_id: 'ocl-search', concept_key: KEY_LOINC_GLUCOSE, type: 'standard' }
+    },
+    concept_rows: {}
+  }
+  assert.deepEqual(getOrphanAlgorithmIds(rowState, ['ocl-search']), [])
+})
+
+test('getOrphanAlgorithmIds ignores candidates with a null/undefined algorithm_id', () => {
+  const rowState = {
+    candidates: {
+      c1: { id: 'c1', algorithm_id: null, concept_key: KEY_LOINC_GLUCOSE, type: 'standard' },
+      c2: { id: 'c2', concept_key: KEY_LOINC_CHOL, type: 'standard' },
+      c3: { id: 'c3', algorithm_id: 'orphan-x', concept_key: KEY_LOINC_GLUCOSE, type: 'standard' }
+    },
+    concept_rows: {}
+  }
+  assert.deepEqual(getOrphanAlgorithmIds(rowState, ['ocl-search']), ['orphan-x'])
+})
+
+test('getOrphanAlgorithmIds orphan id round-trips through buildAlgorithmRowViews into a renderable bucket', () => {
+  // The component appends a bucket per orphan id using buildAlgorithmRowViews
+  // with that id. Assert the full-mix bucket includes a non-target candidate.
+  const cache = { [KEY_LOINC_GLUCOSE]: defLOINCGlucose }
+  const rowState = {
+    candidates: {
+      c1: { id: 'c1', algorithm_id: 'orphan-x', concept_key: KEY_LOINC_GLUCOSE, type: 'standard', score: 0.7 }
+    },
+    concept_rows: {}
+  }
+  const [orphanId] = getOrphanAlgorithmIds(rowState, ['ocl-search'])
+  assert.equal(orphanId, 'orphan-x')
+  const views = buildAlgorithmRowViews(rowState, cache, orphanId)
+  assert.equal(views.length, 1)
+  assert.equal(views[0].candidate.id, 'c1')
 })
 
 // ---------- buildQualityRowViews ----------

--- a/src/components/map-projects/viewBuilders.js
+++ b/src/components/map-projects/viewBuilders.js
@@ -113,6 +113,25 @@ export const buildAlgorithmRowViews = (rowState, conceptCache, algoId) => {
 }
 
 /**
+ * The distinct algorithm_ids present in rowState.candidates that are NOT in
+ * the project's configured algorithm set. These "orphan-algo" candidates are
+ * legitimate (a candidate's algorithm_id is a benign label, never a filter —
+ * membership is gated by target-repo elsewhere) and arise whenever a project
+ * is reconfigured after running algorithms, or via the PR3-C v1->v2 migration.
+ * The by-algorithm grouping iterates only configured algos, so these ids would
+ * otherwise have no bucket. Order is stable (first-seen) for deterministic
+ * rendering. configuredIds may be any iterable of algorithm ids.
+ */
+export const getOrphanAlgorithmIds = (rowState, configuredIds) => {
+  if(!rowState) return []
+  const configured = new Set(configuredIds || [])
+  const present = values(rowState.candidates || {})
+    .map(c => c.algorithm_id)
+    .filter(id => id != null && !configured.has(id))
+  return uniq(present)
+}
+
+/**
  * Quality-grouped view: iterate `RowState.concept_rows`. One entry per
  * concept_key (the per-row presence of a concept). Each entry exposes
  * its rerank_score plus a list of contributing candidates so the UI can

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -523,6 +523,7 @@
     "ciel_bridge_terminology_candidates": "CIEL Bridge Terminology Candidates",
     "fetching": "Fetching...",
     "fetch_more": "Fetch More",
+    "unrecognized_algorithm": "Unrecognized algorithm",
     "source_code": "Source Code",
     "class": "Class",
     "datatype": "Datatype",

--- a/src/i18n/locales/es/translations.json
+++ b/src/i18n/locales/es/translations.json
@@ -494,6 +494,7 @@
     "ciel_bridge_terminology_candidates": "Candidatos de Terminología Puente CIEL",
     "fetching": "Obteniendo...",
     "fetch_more": "Obtener Más",
+    "unrecognized_algorithm": "Algoritmo no reconocido",
     "source_code": "Código Fuente",
     "class": "Clase",
     "datatype": "Tipo de Dato",

--- a/src/i18n/locales/zh/translations.json
+++ b/src/i18n/locales/zh/translations.json
@@ -519,6 +519,7 @@
     "ciel_bridge_terminology_candidates": "CIEL 桥接术语候选对象",
     "fetching": "正在获取...",
     "fetch_more": "获取更多",
+    "unrecognized_algorithm": "无法识别的算法",
     "source_code": "源代码",
     "class": "类",
     "datatype": "数据类型",


### PR DESCRIPTION
closes OpenConceptLab/ocl_issues#2556

## Problem
In the by-algorithm grouping of the Candidates tab, `getCandidates()` iterates only the project's **configured** algorithms (`algosSelected`). A candidate's `algorithm_id` can legitimately fall outside that set — the project was reconfigured after running algorithms, or the PR3-C v1→v2 migration (oclmap#37 / ocl_issues#2555) saved a tag that doesn't match a configured algo id. Those "orphan-algo" candidates appeared in **no bucket** in the by-algorithm view, even though they already render in:
- the default **quality (by-concept) view**, and
- the **AI Assistant payload**

— both gated by target-repo membership (`conceptBelongsToTargetRepo`), never by `algorithm_id`.

## Change
- **`viewBuilders.js`**: add pure, unit-tested helper `getOrphanAlgorithmIds(rowState, configuredIds)` → the distinct candidate `algorithm_id`s not in the configured set (first-seen order, null ids ignored).
- **`Candidates.jsx`** (`getCandidates()` algorithm branch): after the sorted configured algos, append **one bucket per orphan id**, built with the existing `buildAlgorithmRowViews`. Each uses a synthesized `algo` of `{id, name: t('map_project.unrecognized_algorithm'), order: Infinity}` → header renders as `Unrecognized algorithm (<id>)`. The render path only reads `algo.name`/`algo.id`/`algo.type?.…`, so the minimal synthesized object is safe.
- Orphan buckets keep the by-algo **full mix** (no target-repo filter); per-row mappability stays gated downstream by `isTargetRepoView` / `conceptBelongsToTargetRepo`, exactly as for configured algos.
- i18n key `unrecognized_algorithm` added to en/es/zh.

The existing `hasCandidates`-desc / `algo.order`-asc ordering of configured algos is unchanged; orphans are concatenated strictly after all configured buckets.

## Tests
- 5 new unit tests in `__tests__/views.test.js` covering `getOrphanAlgorithmIds` (null rowState, distinct/deduped orphans, all-configured → `[]`, null `algorithm_id` ignored, round-trip into `buildAlgorithmRowViews`).
- `npm test` → 141 pass / 0 fail. `npm run eslint` → clean. `webpack` dev build compiles successfully.

## Out of scope
The migration itself (oclmap#37) and the quality view / AI payload (already surface these candidates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)