### PR TITLE
Enrich saved candidates on row open (no definitions/scores until Refresh)

### DIFF
--- a/src/components/map-projects/MapProject.jsx
+++ b/src/components/map-projects/MapProject.jsx
@@ -3426,6 +3426,35 @@ const MapProject = () => {
     ensureLoadedRef.current = ensureLoaded
   }, [ensureLoaded])
 
+  // Lazily enrich a row's saved candidates when it is opened. The persisted
+  // v2 candidates payload intentionally carries sparse ConceptDefinitions
+  // ('partial'/'pending' — no descriptions, and for migrated projects no
+  // rerank_score); these are designed to be $lookup-resolved on demand. The
+  // refresh / auto-match path triggers that via mergeIntoRowMatchState ->
+  // ensureLoaded -> scheduleRerank, but the project LOAD path
+  // (fetchAndSetProject) deserializes straight into the cache without
+  // enriching. So a saved/migrated row shows blank candidate definitions and
+  // leaves them in the "Unranked" bucket until the user manually hits Refresh
+  // (OpenConceptLab/ocl_issues#2557). Mirror the merge path here: resolve the
+  // row's sparse defs, then rerank so scores land too. The explicit
+  // scheduleRerank is required because writeConceptCachePatch only auto-fires
+  // a rerank on a not-usable -> usable display_name transition — 'partial'
+  // defs already have a usable name, so resolving them alone never re-scores.
+  // ensureLoaded is idempotent + in-flight-deduped and we only fire for rows
+  // that still have sparse defs, so fully-loaded rows are a no-op.
+  React.useEffect(() => {
+    if(!isNumber(rowIndex)) return
+    const conceptRows = rowMatchStateRef.current?.[rowIndex]?.concept_rows
+    if(!conceptRows) return
+    const cache = conceptCacheRef.current || {}
+    const keysToLoad = Object.keys(conceptRows).filter(k => cache[k]?.lookup_status !== 'full')
+    if(keysToLoad.length && ensureLoadedRef.current) {
+      ensureLoadedRef.current(keysToLoad, rowIndex).then(() => {
+        if(scheduleRerankRef.current) scheduleRerankRef.current(rowIndex)
+      })
+    }
+  }, [rowIndex])
+
   const onFetchMoreCandidates = () => {
     const algoDef = getFirstAlgoDef()
     const rowEntry = rowMatchStateRef.current?.[rowIndex]


### PR DESCRIPTION
Closes OpenConceptLab/ocl_issues#2557

## Problem

After the PR3-C v1→v2 candidates migration (#2555), opening a saved map project showed candidates with **no definitions and no score**. Hitting **Refresh candidates** fixed them. Reported by Sunny on `/users/jon/map-projects/144/`.

## Root cause (frontend, not migration data loss)

The v2 candidates wire format intentionally carries sparse `ConceptDefinition`s (`lookup_status: partial | pending` — no `descriptions`, and for migrated projects no `rerank_score`). These are designed to be `$lookup`-resolved on demand via `ensureLoaded()`.

- **Refresh / auto-match path** enriches: `getRowsResults → mergeIntoRowMatchState → ensureLoaded → scheduleRerank` (MapProject.jsx:391-407).
- **Project LOAD path** (`fetchAndSetProject`) deserializes the persisted v2 payload straight into `conceptCache` / `rowMatchState` and **never calls `ensureLoaded`** — so saved/migrated rows stayed blank until a manual refresh.

Verified against prod project 144: of 3,075 displayed `concept_rows`, exactly the `full` defs (1,500) carry a `rerank_score`; the `partial`/`pending` defs (1,575) have **neither descriptions nor score** (perfect 1:1 correlation, 0 anomalies). The migration did **not** drop data — descriptions were never stored inline.

## Fix

A per-row `useEffect` (keyed on the selected `rowIndex`) that mirrors the merge path when a row is opened: resolve the row’s sparse defs via `ensureLoaded`, then `scheduleRerank` so scores land too.

- The explicit `scheduleRerank` is required because `writeConceptCachePatch` only auto-fires a rerank on a **not-usable → usable** `display_name` transition, and `partial` defs already have a usable name — so resolving them alone never re-scores them.
- `ensureLoaded` is idempotent + in-flight-deduped, and the effect only fires for rows that still have sparse defs, so fully-loaded rows are a no-op (no extra fetch, no redundant rerank). Lazy per-opened-row, so no full-project enrichment stampede on load.

## Verification (local dev → prod API, project 144)

- Before: row open fired **zero** `$resolveReference` / verbose concept fetches; candidates blank + in "Unranked" bucket.
- After (single click on a row): fires `POST /$resolveReference/` → verbose `GET /concepts/{code}/?...&verbose=true` for each sparse candidate → `POST /concepts/$rerank/`. Candidates render full definitions + percentage scores, sorted into Recommended/Available/Low Ranked (no "Unranked" bucket).
- `npm test` → 141/141 pass. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)