### PR TITLE
OpenConceptLab/ocl_issues#2558 | Divert target-repo concept fetch to custom lookup source

### DIFF
--- a/src/components/map-projects/MapProject.jsx
+++ b/src/components/map-projects/MapProject.jsx
@@ -99,7 +99,7 @@ import ProjectLogs from './ProjectLogs';
 import { useAlgos, ensureConceptIdentity } from './algorithms'
 import AutoMatchDialog from './AutoMatchDialog'
 import { DEFAULT_ENCODER_MODEL } from './rerankerModels'
-import { normalizeAlgorithmInvocation, lookupStatusRank, buildRecommendableConceptEntry, stripConstantClassAndDatatype } from './normalizers'
+import { normalizeAlgorithmInvocation, lookupStatusRank, buildRecommendableConceptEntry, stripConstantClassAndDatatype, buildLookupConceptUrl } from './normalizers'
 import { parseConceptKey } from './conceptKey'
 import { getDefaultTargetRepoVersion, getProjectTargetRepoVersion, getTargetRepoVersionFromUrl, getTargetRepoVersionId } from './projectTargetRepo'
 import { buildQualityRowViews, conceptBelongsToTargetRepo, conceptForMapping, resolveAICandidateID } from './viewBuilders.js'
@@ -3303,7 +3303,19 @@ const MapProject = () => {
       pending.push(promise)
 
       if(def?.ocl_url) {
-        directFetches.push({key, oclUrl: def.ocl_url})
+        // The target repo may be a definition-only canonical repo whose content
+        // is served from a configured custom lookup source (e.g. the public WHO
+        // ICD-11 repo, kept content-empty under WHO's license). Concepts that
+        // resolve to the target repo — notably ocl-bridge cascade targets, whose
+        // ocl_url points INTO the (empty) target repo — 404 on a direct GET.
+        // Divert those to the lookup source by code. Branch 2 ($resolveReference,
+        // below) already honors lookupConfig.url; this brings the direct-fetch
+        // branch in line. See ocl_issues#2558.
+        const tr = ctx?.target_repo
+        const divertedUrl = (lookupConfig?.url && tr && conceptBelongsToTargetRepo(def, tr.canonical_url, tr.relative_url))
+          ? buildLookupConceptUrl(lookupConfig.url, def.reference?.code)
+          : null
+        directFetches.push({key, oclUrl: divertedUrl || def.ocl_url})
       } else {
         try {
           const reference = parseConceptKey(key)

--- a/src/components/map-projects/__tests__/normalizers.test.js
+++ b/src/components/map-projects/__tests__/normalizers.test.js
@@ -26,7 +26,8 @@ import {
   filterAndTrimNames,
   filterAndTrimDescriptions,
   primarySubtag,
-  uniqByPrimarySubtag
+  uniqByPrimarySubtag,
+  buildLookupConceptUrl
 } from '../normalizers.js'
 import { makeConceptKey, parseConceptKey, referencesEqual } from '../conceptKey.js'
 
@@ -1568,4 +1569,46 @@ test('buildRecommendableConceptEntry: union effectiveLocales=["pt","en"] surface
 
   const langs = entry.names.map(n => primarySubtag(n.locale)).sort()
   assert.deepEqual(langs, ['en', 'en', 'pt'])
+})
+
+// ---------- buildLookupConceptUrl ----------
+// URL builder used by MapProject.ensureLoaded to divert target-repo concept
+// fetches to the configured custom lookup source. ocl_issues#2558.
+// (The "should this divert?" predicate is conceptBelongsToTargetRepo in
+// viewBuilders.js; this helper only builds the lookup-source URL.)
+
+const LOOKUP_URL = '/orgs/OpenMRS-OCL-Squad/sources/ICD-11-WHO-Mapper/'
+
+test('buildLookupConceptUrl: builds a lookup-source concept URL by code', () => {
+  assert.equal(
+    buildLookupConceptUrl(LOOKUP_URL, 'BD11.Z'),
+    '/orgs/OpenMRS-OCL-Squad/sources/ICD-11-WHO-Mapper/concepts/BD11.Z/'
+  )
+})
+
+test('buildLookupConceptUrl: double-encodes cluster (&) and compound (/) codes', () => {
+  // Matches the $resolveReference (Branch 2) double-encode so both fetch paths
+  // address the same concept (verified against successful run fetches).
+  assert.equal(
+    buildLookupConceptUrl(LOOKUP_URL, 'ND92.1&XA55T2'),
+    '/orgs/OpenMRS-OCL-Squad/sources/ICD-11-WHO-Mapper/concepts/ND92.1%2526XA55T2/'
+  )
+  assert.equal(
+    buildLookupConceptUrl(LOOKUP_URL, 'GB4Y/MF8Y'),
+    '/orgs/OpenMRS-OCL-Squad/sources/ICD-11-WHO-Mapper/concepts/GB4Y%252FMF8Y/'
+  )
+})
+
+test('buildLookupConceptUrl: appends a trailing slash to the base when missing', () => {
+  assert.equal(
+    buildLookupConceptUrl('/orgs/X/sources/Y', 'QC00.5'),
+    '/orgs/X/sources/Y/concepts/QC00.5/'
+  )
+})
+
+test('buildLookupConceptUrl: returns null on missing input', () => {
+  assert.equal(buildLookupConceptUrl(undefined, 'BD11.Z'), null)
+  assert.equal(buildLookupConceptUrl('', 'BD11.Z'), null)
+  assert.equal(buildLookupConceptUrl(LOOKUP_URL, undefined), null)
+  assert.equal(buildLookupConceptUrl(LOOKUP_URL, ''), null)
 })

--- a/src/components/map-projects/normalizers.js
+++ b/src/components/map-projects/normalizers.js
@@ -121,6 +121,25 @@ const resolveReference = (result, identityConfig, projectContext) => {
 }
 
 /**
+ * Build the concept-detail URL for a custom lookup source, addressed by code.
+ *
+ * Mirrors the `$resolveReference` (Branch 2) fetch path in
+ * MapProject.ensureLoaded — same base + double-encode — so a code resolves to
+ * the identical URL whether it arrives with an `ocl_url` (direct branch) or via
+ * `$resolveReference`. The double-encode keeps cluster (`&`) and compound (`/`)
+ * codes addressable.
+ *
+ * @param {string} [lookupUrl]  lookupConfig.url — the custom lookup source
+ * @param {string} [code]       the concept code
+ * @returns {string|null}       the lookup-source concept URL, or null on missing input
+ */
+export const buildLookupConceptUrl = (lookupUrl, code) => {
+  if (!lookupUrl || !code) return null
+  const base = lookupUrl.endsWith('/') ? lookupUrl : `${lookupUrl}/`
+  return `${base}concepts/${encodeURIComponent(encodeURIComponent(code))}/`
+}
+
+/**
  * Build a ConceptDefinition from a concept-shaped result + a resolved reference.
  */
 const toConceptDefinition = (result, reference, identityConfig, { algorithmId } = {}) => {


### PR DESCRIPTION
Fixes the symptom in **ocl_issues#2558**. @snyaggarwal for review.

> ⚠️ **Not 100% certain this is the right approach** — posting for your judgment. The diagnosis is solid; the *fix location/shape* is the open question (see below). Happy to move it elsewhere or scope it differently.

## Problem

When a map project uses a **custom lookup source** because its target repo is a *definition/metadata-only* canonical repo (e.g. the public WHO `ICD-11-WHO` repo, kept content-empty under WHO's license), some concept-detail GETs still hit the empty target repo and **404**.

`ensureLoaded` resolves not-yet-`full` ConceptDefinitions two ways:
- **Branch 2** (no `ocl_url` → `$resolveReference`) already honors `lookupConfig.url`.
- **Branch 1** (has `ocl_url` → direct GET) fetched the `ocl_url` **verbatim**, never consulting `lookupConfig`.

`ocl-bridge` / `ocl-ciel-bridge` **cascade targets** resolve against the target repo (`concept_identity.cascade_target.reference_source: 'target_repo'`) and arrive with an `ocl_url` that points **into the target repo** → they take Branch 1 → fetch the empty repo → 404.

### Evidence
ICD-11 IMO eval run (target `WHO/ICD-11-WHO`, lookup `OpenMRS-OCL-Squad/ICD-11-WHO-Mapper`): 6 GETs hit `/orgs/WHO/sources/ICD-11-WHO/concepts/<code>/` and 404'd; the same codes return 200 from the lookup source. Failing URLs were **not** double-encoded → confirms Branch 1 (only Branch 2 double-encodes). The fetch is state-driven (`mergeIntoRowMatchState` → `ensureLoaded` on not-`full` arrival), not triggered by opening the details panel.

## Change

In Branch 1, when the concept belongs to the target repo **and** a lookup source is configured, fetch the lookup source by code instead of the target-repo `ocl_url`:

```js
const tr = ctx?.target_repo
const divertedUrl = (lookupConfig?.url && tr && conceptBelongsToTargetRepo(def, tr.canonical_url, tr.relative_url))
  ? buildLookupConceptUrl(lookupConfig.url, def.reference?.code)
  : null
directFetches.push({key, oclUrl: divertedUrl || def.ocl_url})
```

- Reuses the existing **`conceptBelongsToTargetRepo`** predicate (canonical-equal OR `ocl_url` starts with the target relative URL) rather than a hand-rolled equality.
- New **`buildLookupConceptUrl`** (normalizers) shares the Branch 2 double-encode so a code resolves to the same URL on both paths. Pure + unit-tested.
- `fetchConceptByOclUrl`'s existing URL-dedup + 404-retry apply unchanged.

`npm test` 145/145, eslint clean.

## Why no server-side change
`WHO/ICD-11-WHO` being empty is **by design** (definition-only canonical repo, WHO license). Content lives in the lookup source. So this is purely client-side routing.

## Open questions for review (the "not certain" parts)
1. **Right layer?** This fixes the direct-fetch branch in `ensureLoaded`. Should the diversion instead live where the cascade-target `ConceptDefinition.ocl_url` is *minted* (normalizers `cascadeTargetToConceptDefinition`), so the stub never carries a target-repo `ocl_url` in the first place? That might be the more principled fix.
2. **Scope.** The predicate diverts *all* target-repo concepts, not just bridge cascade targets. Standard `$match` candidates already carry a lookup-source `ocl_url`, so rebuilding lands at the same place (harmless) — but confirm that's acceptable vs. narrowing to bridge targets only.
3. **Versioning.** I deliberately fetch `lookupConfig.url` as configured and don't graft the target's pinned version onto it (matches Branch 2). Correct for your intended semantics?
4. **Relation to #2515** ("separate lookup sources per algorithm / fallback to target repo") — should this fold into that work instead of landing standalone?

Background analysis (HAR forensics + repro) lives in the ocl-mapper-eval `2026-06-02-imo-prepub` run notes; happy to share.