### PR TITLE
Mapper UI auto-match attribution: AutomatchRun lifecycle + propagation headers (ocl_online#105 Phase 5)

### DIFF
--- a/src/components/map-projects/MapProject.jsx
+++ b/src/components/map-projects/MapProject.jsx
@@ -68,6 +68,7 @@ import pick from 'lodash/pick'
 import { OperationsContext } from '../app/LayoutContext';
 
 import APIService, { isTransientNetworkError, retryWithBackoff } from '../../services/APIService';
+import { buildAttributionHeaders, buildConfigSnapshot } from '../../services/attribution'
 import { highlightTexts, dropVersion, getCurrentUser, hasAuthGroup, downloadObject, currentUserToken } from '../../common/utils';
 import { WHITE, SURFACE_COLORS } from '../../common/colors';
 
@@ -199,6 +200,10 @@ const MapProject = () => {
   const abortRef = React.useRef(false);
   const isBulkMatchRunningRef = React.useRef(false);
   const bulkMatchAlgoIdsRef = React.useRef([]);
+  // ocl_online#105 Phase 5: the active AutomatchRun ({id, algoIds}) or null.
+  // A ref so every per-row backend call reads the run id synchronously without
+  // prop-drilling or re-renders; null outside a run → 'mapper-ui-manual'.
+  const automatchRunRef = React.useRef(null);
 
   const [row, setRow] = React.useState(false)
   const [loadingMatches, setLoadingMatches] = React.useState(false)
@@ -1294,6 +1299,77 @@ const MapProject = () => {
       APIService.new().overrideURL(project.url).appendToUrl('logs/').post({logs: {row_logs: logs, project_logs: newLogs}}).then(() => {})
   }
 
+  // ── ocl_online#105 Phase 5: AutomatchRun attribution ──────────────────────
+  // Build the X-OCL-Request-Source + X-OCL-Event-Metadata headers for a single
+  // per-row backend call. Reads the active run id from the ref, so the same
+  // call sites used outside a run emit request_source='mapper-ui-manual'.
+  const attrHeaders = ({rowIndex, rowIndices, batchSize, algorithmId, clientAttemptN} = {}) =>
+    buildAttributionHeaders({
+      runId: automatchRunRef.current?.id ?? null,
+      projectId: params.projectId,
+      rowIndex, rowIndices, batchSize, algorithmId, clientAttemptN,
+    })
+
+  // Create the AutomatchRun system-of-record at run start (oclapi2#876). The
+  // server stamps started_by / client_user_agent / client_ip itself, so we send
+  // only the run-start snapshot. Degrades gracefully: a failed create leaves the
+  // ref null and the auto-match run proceeds (per-row calls fall back to
+  // 'mapper-ui-manual') — run creation must never block matching.
+  const createAutomatchRun = async (selectedAlgos, intendedRows) => {
+    automatchRunRef.current = null
+    if(!project?.url || !intendedRows?.length) return
+    const withAI = Boolean(inAIAssistantGroup && autoRunAIAnalysis)
+    const body = {
+      intended_rows: intendedRows.length,
+      trigger_source: 'ui-auto-match',
+      config_snapshot: buildConfigSnapshot({
+        selectedAlgos,
+        encoderModel,
+        scoreConfig: candidatesScore,
+        filters: getFilters(),
+        template: withAI ? getPromptTemplateRef() : null,
+        aiModel: withAI ? (getSelectedAIModel()?.id || AIModel) : null,
+      }),
+    }
+    try {
+      const response = await APIService.new().overrideURL(project.url).appendToUrl('auto-match-runs/').post(body)
+      const id = response?.data?.id
+      if(id) automatchRunRef.current = {id, algoIds: map(selectedAlgos, 'id')}
+      else projectLog({action: 'automatch_run_create_failed', extras: {status: response?.status || 'no-id'}})
+    } catch (err) {
+      projectLog({action: 'automatch_run_create_failed', extras: {error: err?.message || 'unknown'}})
+    }
+  }
+
+  // PATCH the run to a terminal status at run end. completed/failed are derived
+  // from the per-row algo stages (rowStageRef: -2 failed, 1 done, -1 not run)
+  // over the rows we set out to process; a row counts as failed only when EVERY
+  // attempted algo failed for it. Never throws — a failed PATCH (or a run that
+  // was never created) must not surface to the user.
+  const completeAutomatchRun = async (selectedAlgos, intendedRows) => {
+    const run = automatchRunRef.current
+    automatchRunRef.current = null
+    if(!run?.id) return
+    const stages = rowStageRef.current || []
+    const algoIds = run.algoIds?.length ? run.algoIds : map(selectedAlgos, 'id')
+    let failed = 0
+    forEach(intendedRows, _row => {
+      const rowStage = stages[_row.__index] || {}
+      const attempted = algoIds.map(id => rowStage[id]).filter(s => s !== undefined && s !== -1)
+      if(attempted.length && attempted.every(s => s === -2)) failed += 1
+    })
+    const total = intendedRows.length
+    const completed = total - failed
+    let completionStatus = 'completed'
+    if(abortRef.current) completionStatus = 'cancelled'
+    else if(completed === 0 && failed > 0) completionStatus = 'failed'
+    else if(failed > 0) completionStatus = 'partial'
+    try {
+      await APIService.new().overrideURL('/auto-match-runs/' + run.id + '/')
+        .request('PATCH', {completed_rows: completed, failed_rows: failed, completion_status: completionStatus})
+    } catch (_) { /* attribution is best-effort; never block on the PATCH */ }
+  }
+
   const fetchRepo = (url, _repo) => APIService.new().overrideURL(url).get().then(response => setRepo(response.data?.id ? response.data : _repo))
 
   const fetchMappedSources = (url, setter) => {
@@ -1507,7 +1583,7 @@ const MapProject = () => {
         const response = await service.post(
           payload,
           (algo.type === 'custom' && algo.url && algo.token) ? algo.token : null,
-          null,
+          attrHeaders({rowIndices: map(rowBatch, '__index'), batchSize: rowBatch.length, algorithmId: algo.id}),
           {
             includeSearchMeta: true,
             ...(algo.query_params || {}),
@@ -1638,59 +1714,67 @@ const MapProject = () => {
         ? filter(rows, row => rowStatuses.unmapped.includes(row.__index))
         : filter(rows, row => !rowStatuses.reviewed.includes(row.__index))
 
-      bulkMatchAlgoIdsRef.current = map(_selectedAlgos, 'id')
-      // Reset all algo stages to -1 for every row before starting so that
-      // stages from a previous run don't make the "all algos done" check
-      // pass prematurely when only the first algo has finished.
-      setRowStage(prev => {
-        const next = { ...prev }
-        rowsToProcess.forEach(row => {
-          const rowId = row.__index
-          const rowState = { ...(next[rowId] || {}) }
-          _selectedAlgos.forEach(algo => { rowState[algo.id] = -1 })
-          next[rowId] = rowState
-        })
-        rowStageRef.current = next
-        return next
-      })
-      isBulkMatchRunningRef.current = true
+      // ocl_online#105 Phase 5: open the run record, then guarantee it is
+      // closed out (completed / partial / failed / cancelled) via the finally,
+      // even on cancel or an unexpected throw mid-pipeline.
+      await createAutomatchRun(_selectedAlgos, rowsToProcess)
       try {
-        for(const algo of _selectedAlgos) {
-          if(abortRef.current) break
-          if(['custom', 'ocl-search', 'ocl-semantic'].includes(algo.type))
-            await processWithConcurrency(repo, algo, rowsToProcess)
-          else if(['ocl-bridge', 'ocl-ciel-bridge'].includes(algo.type) && canBridge)
-            await fetchBulkBridgeCandidates(rowsToProcess, algo)
-          else if(algo.type === 'ocl-scispacy' && canScispacy)
-            await fetchBulkScispacyCandidates(rowsToProcess, algo)
-        }
-      } finally {
-        isBulkMatchRunningRef.current = false
-        bulkMatchAlgoIdsRef.current = []
-      }
-      if(_selectedAlgos.length)
-        await processRerankWithConcurrency(rowsToProcess, 2)
-      if(inAIAssistantGroup && autoRunAIAnalysis) {
-        await new Promise(resolve => setTimeout(resolve, 1000))
-        await runBulkAIAnalysis(rowsToProcess)
-      } else {
-        setIsLoadingInDecisionView(false)
-        setLoadingMatches(false)
-        setEndMatchingAt(moment())
-      }
-      if(!abortRef.current)
-        projectLog({
-          action: 'auto_match_finished',
-          extras: {
-            sub_actions: subActions,
-            ...(inAIAssistantGroup && autoRunAIAnalysis ? {
-              ai_assistant: {
-                model: getSelectedAIModel(),
-                prompt_template: getPromptTemplateRef()
-              }
-            } : {})
-          }
+        bulkMatchAlgoIdsRef.current = map(_selectedAlgos, 'id')
+        // Reset all algo stages to -1 for every row before starting so that
+        // stages from a previous run don't make the "all algos done" check
+        // pass prematurely when only the first algo has finished.
+        setRowStage(prev => {
+          const next = { ...prev }
+          rowsToProcess.forEach(row => {
+            const rowId = row.__index
+            const rowState = { ...(next[rowId] || {}) }
+            _selectedAlgos.forEach(algo => { rowState[algo.id] = -1 })
+            next[rowId] = rowState
+          })
+          rowStageRef.current = next
+          return next
         })
+        isBulkMatchRunningRef.current = true
+        try {
+          for(const algo of _selectedAlgos) {
+            if(abortRef.current) break
+            if(['custom', 'ocl-search', 'ocl-semantic'].includes(algo.type))
+              await processWithConcurrency(repo, algo, rowsToProcess)
+            else if(['ocl-bridge', 'ocl-ciel-bridge'].includes(algo.type) && canBridge)
+              await fetchBulkBridgeCandidates(rowsToProcess, algo)
+            else if(algo.type === 'ocl-scispacy' && canScispacy)
+              await fetchBulkScispacyCandidates(rowsToProcess, algo)
+          }
+        } finally {
+          isBulkMatchRunningRef.current = false
+          bulkMatchAlgoIdsRef.current = []
+        }
+        if(_selectedAlgos.length)
+          await processRerankWithConcurrency(rowsToProcess, 2)
+        if(inAIAssistantGroup && autoRunAIAnalysis) {
+          await new Promise(resolve => setTimeout(resolve, 1000))
+          await runBulkAIAnalysis(rowsToProcess)
+        } else {
+          setIsLoadingInDecisionView(false)
+          setLoadingMatches(false)
+          setEndMatchingAt(moment())
+        }
+        if(!abortRef.current)
+          projectLog({
+            action: 'auto_match_finished',
+            extras: {
+              sub_actions: subActions,
+              ...(inAIAssistantGroup && autoRunAIAnalysis ? {
+                ai_assistant: {
+                  model: getSelectedAIModel(),
+                  prompt_template: getPromptTemplateRef()
+                }
+              } : {})
+            }
+          })
+      } finally {
+        await completeAutomatchRun(_selectedAlgos, rowsToProcess)
+      }
     }, 1000)
   };
 
@@ -2957,7 +3041,7 @@ const MapProject = () => {
         q: query,
         rows: rerankRows,
         ...(encoderModel ? { encoder_model: encoderModel } : {})
-      })
+      }, null, attrHeaders({rowIndex: index, algorithmId: 'reranker'}))
 
       // Write rerank_score into the row's ConceptRows. matchRerankResultToKey
       // throws on canonical-identity miss; surface to the alert state so a
@@ -3244,7 +3328,11 @@ const MapProject = () => {
           setAlert({message: response?.detail || errorMsg, severity: 'error'})
           setIsLoadingInDecisionView(false)
           resolve()
-        }
+        },
+        // ocl_online#105 Phase 5: attribution headers for the bridge $match,
+        // applied by the premium component (react-bridge-match). Per-row here
+        // (single-row payload) → scalar row_index.
+        attrHeaders({rowIndex: __row.__index, algorithmId: bridgeAlgoId})
       )
     })
   }
@@ -3391,7 +3479,7 @@ const MapProject = () => {
           } else {
             service = service.overrideURL(oclUrl)
           }
-          const response = await service.request('GET', undefined, authToken, {query: {includeMappings: true, mappingBrief: true, mapTypes: 'SAME-AS,SAME AS,SAME_AS', verbose: true}})
+          const response = await service.request('GET', undefined, authToken, {query: {includeMappings: true, mappingBrief: true, mapTypes: 'SAME-AS,SAME AS,SAME_AS', verbose: true}, headers: attrHeaders({rowIndex: logRowIndex})})
           const data = response?.data
           if(data?.id) return data
           urlFetchCacheRef.current.delete(oclUrl)
@@ -3448,7 +3536,7 @@ const MapProject = () => {
         : {url: reference.url})
       resolvePromise = APIService.new()
         .overrideURL('/$resolveReference/')
-        .post(body, currentToken, null, resolveNamespace ? {namespace: resolveNamespace} : undefined)
+        .post(body, currentToken, attrHeaders({rowIndex: logRowIndex}), resolveNamespace ? {namespace: resolveNamespace} : undefined)
         .then(async response => {
           const items = Array.isArray(response?.data) ? response.data : []
           await Promise.all(toResolve.map(async ({key, reference}, i) => {
@@ -4061,7 +4149,14 @@ const MapProject = () => {
       const invokeTs = Date.now()
       try {
         const response = await retryWithBackoff(
-          attempt => service.request('POST', payload, undefined, {headers: {'X-OCL-REQUEST-IDEMPOTENCY-KEY': `${params.projectId}-${__index}-${attempt}-${invokeTs}`}}),
+          attempt => service.request('POST', payload, undefined, {headers: {
+            'X-OCL-REQUEST-IDEMPOTENCY-KEY': `${params.projectId}-${__index}-${attempt}-${invokeTs}`,
+            // Discrete headers (read into event_metadata by the middleware); not
+            // bundled into the JSON bag. attrHeaders adds request_source + the bag.
+            ...(promptTemplateRef?.key ? {'X-OCL-PROMPT-TEMPLATE-KEY': promptTemplateRef.key} : {}),
+            ...(promptTemplateRef?.version ? {'X-OCL-PROMPT-TEMPLATE-VERSION': String(promptTemplateRef.version)} : {}),
+            ...attrHeaders({rowIndex: __index, clientAttemptN: attempt + 1}),
+          }}),
           {
             maxRetries: 2,
             baseDelayMs: 3000,

--- a/src/components/map-projects/MapProject.jsx
+++ b/src/components/map-projects/MapProject.jsx
@@ -2872,7 +2872,11 @@ const MapProject = () => {
     while(warmingUp) {
       if(abortRef.current) { setIsLoadingInDecisionView(false); return }
       try {
-        const response = await service.post(payload)
+        // ocl_online#105 Phase 5: the scispacy service records its own
+        // api_transactions (ocl-scispacy-loinc) via its AnalyticsMiddleware, so
+        // attribute the $match like the others. Per-row (single-row payload) →
+        // scalar row_index; isBulk distinguishes a run call from a manual one.
+        const response = await service.post(payload, null, attrHeaders({rowIndex: __row.__index, algorithmId: 'ocl-scispacy-loinc', isRunTraffic: isBulk}))
 
         // APIService resolves 5xx errors with error.response.data, so response
         // is the parsed body object — not the axios response. A 503 warming_up

--- a/src/components/map-projects/MapProject.jsx
+++ b/src/components/map-projects/MapProject.jsx
@@ -68,7 +68,7 @@ import pick from 'lodash/pick'
 import { OperationsContext } from '../app/LayoutContext';
 
 import APIService, { isTransientNetworkError, retryWithBackoff } from '../../services/APIService';
-import { buildAttributionHeaders, buildConfigSnapshot } from '../../services/attribution'
+import { buildAttributionHeaders, buildConfigSnapshot, summarizeRunCompletion } from '../../services/attribution'
 import { highlightTexts, dropVersion, getCurrentUser, hasAuthGroup, downloadObject, currentUserToken } from '../../common/utils';
 import { WHITE, SURFACE_COLORS } from '../../common/colors';
 
@@ -300,7 +300,10 @@ const MapProject = () => {
    */
   const mergeIntoRowMatchState = React.useCallback((rowIndex, normalized, options = {}) => {
     if(!normalized) return
-    const { append = false } = options
+    // isRunTraffic (ocl_online#105 Phase 5): true only when the merge originates
+    // from the bulk auto-match pipeline, so the ensureLoaded reads it triggers
+    // are attributed to the run; manual merges leave it false → mapper-ui-manual.
+    const { append = false, isRunTraffic = false } = options
     const { algorithm_response, candidates, concept_definitions, concept_rows } = normalized
     const incomingAlgoId = algorithm_response?.algorithm_id
 
@@ -395,7 +398,7 @@ const MapProject = () => {
         .filter(d => d && d.lookup_status !== 'full')
         .map(d => d.key)
       if(keysToLoad.length) {
-        ensureLoadedRef.current(keysToLoad, rowIndex).then(() => {
+        ensureLoadedRef.current(keysToLoad, rowIndex, isRunTraffic).then(() => {
           if(scheduleRerankRef.current) scheduleRerankRef.current(rowIndex)
         })
       }
@@ -1301,11 +1304,14 @@ const MapProject = () => {
 
   // ── ocl_online#105 Phase 5: AutomatchRun attribution ──────────────────────
   // Build the X-OCL-Request-Source + X-OCL-Event-Metadata headers for a single
-  // per-row backend call. Reads the active run id from the ref, so the same
-  // call sites used outside a run emit request_source='mapper-ui-manual'.
-  const attrHeaders = ({rowIndex, rowIndices, batchSize, algorithmId, clientAttemptN} = {}) =>
+  // per-row backend call. Attribution is by explicit ORIGIN, not ambient: only
+  // calls the bulk auto-match pipeline drives pass isRunTraffic, so a manual
+  // call (panel open, single rerun, per-row AI) that overlaps a running
+  // auto-match is correctly stamped 'mapper-ui-manual' — the active-run ref
+  // alone can't distinguish concurrent manual traffic from run traffic.
+  const attrHeaders = ({rowIndex, rowIndices, batchSize, algorithmId, clientAttemptN, isRunTraffic = false} = {}) =>
     buildAttributionHeaders({
-      runId: automatchRunRef.current?.id ?? null,
+      runId: isRunTraffic ? (automatchRunRef.current?.id ?? null) : null,
       projectId: params.projectId,
       rowIndex, rowIndices, batchSize, algorithmId, clientAttemptN,
     })
@@ -1350,23 +1356,15 @@ const MapProject = () => {
     const run = automatchRunRef.current
     automatchRunRef.current = null
     if(!run?.id) return
-    const stages = rowStageRef.current || []
-    const algoIds = run.algoIds?.length ? run.algoIds : map(selectedAlgos, 'id')
-    let failed = 0
-    forEach(intendedRows, _row => {
-      const rowStage = stages[_row.__index] || {}
-      const attempted = algoIds.map(id => rowStage[id]).filter(s => s !== undefined && s !== -1)
-      if(attempted.length && attempted.every(s => s === -2)) failed += 1
+    const payload = summarizeRunCompletion({
+      rowStages: rowStageRef.current || [],
+      rowIndices: map(intendedRows, '__index'),
+      algoIds: run.algoIds?.length ? run.algoIds : map(selectedAlgos, 'id'),
+      aborted: abortRef.current,
     })
-    const total = intendedRows.length
-    const completed = total - failed
-    let completionStatus = 'completed'
-    if(abortRef.current) completionStatus = 'cancelled'
-    else if(completed === 0 && failed > 0) completionStatus = 'failed'
-    else if(failed > 0) completionStatus = 'partial'
     try {
       await APIService.new().overrideURL('/auto-match-runs/' + run.id + '/')
-        .request('PATCH', {completed_rows: completed, failed_rows: failed, completion_status: completionStatus})
+        .request('PATCH', payload)
     } catch (_) { /* attribution is best-effort; never block on the PATCH */ }
   }
 
@@ -1583,7 +1581,7 @@ const MapProject = () => {
         const response = await service.post(
           payload,
           (algo.type === 'custom' && algo.url && algo.token) ? algo.token : null,
-          attrHeaders({rowIndices: map(rowBatch, '__index'), batchSize: rowBatch.length, algorithmId: algo.id}),
+          attrHeaders({rowIndices: map(rowBatch, '__index'), batchSize: rowBatch.length, algorithmId: algo.id, isRunTraffic: true}),
           {
             includeSearchMeta: true,
             ...(algo.query_params || {}),
@@ -1645,7 +1643,7 @@ const MapProject = () => {
                       // that flag was true — otherwise it's a per-algo native score
                       // (e.g. FAISS similarity × 100) masquerading as a rerank.
                       trustServerRerank: !isMultiAlgo
-                    }))
+                    }), {isRunTraffic: true})
                   })
                 }
               }
@@ -1800,7 +1798,7 @@ const MapProject = () => {
     for (let index = 0; index < _rows.length; index++) {
       if (abortRef.current) break;
 
-      await fetchRecommendation(_rows[index], resolvedPromptTemplate);
+      await fetchRecommendation(_rows[index], resolvedPromptTemplate, true);
     }
     const now = moment()
     setBulkAIAnalysisEndedAt(now)
@@ -1835,7 +1833,7 @@ const MapProject = () => {
             projectContext: buildProjectContext(),
             rowIndex: index,
             rawResponse: response
-          }))
+          }), {isRunTraffic: true})
         }
       })); // wait for completion
       await new Promise(resolve => setTimeout(resolve, 200)); // 1s delay
@@ -1872,7 +1870,7 @@ const MapProject = () => {
             projectContext: buildProjectContext(),
             rowIndex: _index,
             rawResponse: response
-          }))
+          }), {isRunTraffic: true})
         }
       })); // wait for completion
       await new Promise(resolve => setTimeout(resolve, 500)); // 1s delay
@@ -3041,7 +3039,7 @@ const MapProject = () => {
         q: query,
         rows: rerankRows,
         ...(encoderModel ? { encoder_model: encoderModel } : {})
-      }, null, attrHeaders({rowIndex: index, algorithmId: 'reranker'}))
+      }, null, attrHeaders({rowIndex: index, algorithmId: 'reranker', isRunTraffic: isBulk}))
 
       // Write rerank_score into the row's ConceptRows. matchRerankResultToKey
       // throws on canonical-identity miss; surface to the alert state so a
@@ -3331,8 +3329,9 @@ const MapProject = () => {
         },
         // ocl_online#105 Phase 5: attribution headers for the bridge $match,
         // applied by the premium component (react-bridge-match). Per-row here
-        // (single-row payload) → scalar row_index.
-        attrHeaders({rowIndex: __row.__index, algorithmId: bridgeAlgoId})
+        // (single-row payload) → scalar row_index. isBulk distinguishes a run
+        // call from a manual per-row bridge fetch.
+        attrHeaders({rowIndex: __row.__index, algorithmId: bridgeAlgoId, isRunTraffic: isBulk})
       )
     })
   }
@@ -3404,7 +3403,7 @@ const MapProject = () => {
     writeConceptCachePatch(key, { ...existing, lookup_status: 'failed' })
   }, [writeConceptCachePatch])
 
-  const ensureLoaded = React.useCallback(async (conceptKeys, logRowIndex) => {
+  const ensureLoaded = React.useCallback(async (conceptKeys, logRowIndex, isRunTraffic = false) => {
     if(!Array.isArray(conceptKeys) || conceptKeys.length === 0) return
     const ctx = buildProjectContext()
     const resolveNamespace = ctx?.namespace
@@ -3479,7 +3478,7 @@ const MapProject = () => {
           } else {
             service = service.overrideURL(oclUrl)
           }
-          const response = await service.request('GET', undefined, authToken, {query: {includeMappings: true, mappingBrief: true, mapTypes: 'SAME-AS,SAME AS,SAME_AS', verbose: true}, headers: attrHeaders({rowIndex: logRowIndex})})
+          const response = await service.request('GET', undefined, authToken, {query: {includeMappings: true, mappingBrief: true, mapTypes: 'SAME-AS,SAME AS,SAME_AS', verbose: true}, headers: attrHeaders({rowIndex: logRowIndex, isRunTraffic})})
           const data = response?.data
           if(data?.id) return data
           urlFetchCacheRef.current.delete(oclUrl)
@@ -3536,7 +3535,7 @@ const MapProject = () => {
         : {url: reference.url})
       resolvePromise = APIService.new()
         .overrideURL('/$resolveReference/')
-        .post(body, currentToken, attrHeaders({rowIndex: logRowIndex}), resolveNamespace ? {namespace: resolveNamespace} : undefined)
+        .post(body, currentToken, attrHeaders({rowIndex: logRowIndex, isRunTraffic}), resolveNamespace ? {namespace: resolveNamespace} : undefined)
         .then(async response => {
           const items = Array.isArray(response?.data) ? response.data : []
           await Promise.all(toResolve.map(async ({key, reference}, i) => {
@@ -4070,7 +4069,7 @@ const MapProject = () => {
     }
   }
 
-  const fetchRecommendation = async (_row, resolvedPromptTemplate = null) => {
+  const fetchRecommendation = async (_row, resolvedPromptTemplate = null, isBulk = false) => {
     let __row = row;
     let __index = rowIndex;
     if(isNumber(_row?.__index)){
@@ -4155,7 +4154,7 @@ const MapProject = () => {
             // bundled into the JSON bag. attrHeaders adds request_source + the bag.
             ...(promptTemplateRef?.key ? {'X-OCL-PROMPT-TEMPLATE-KEY': promptTemplateRef.key} : {}),
             ...(promptTemplateRef?.version ? {'X-OCL-PROMPT-TEMPLATE-VERSION': String(promptTemplateRef.version)} : {}),
-            ...attrHeaders({rowIndex: __index, clientAttemptN: attempt + 1}),
+            ...attrHeaders({rowIndex: __index, clientAttemptN: attempt + 1, isRunTraffic: isBulk}),
           }}),
           {
             maxRetries: 2,

--- a/src/services/__tests__/attribution.test.js
+++ b/src/services/__tests__/attribution.test.js
@@ -17,6 +17,7 @@ import assert from 'node:assert/strict'
 import {
   buildAttributionHeaders,
   buildConfigSnapshot,
+  summarizeRunCompletion,
   REQUEST_SOURCE,
   REQUEST_SOURCE_HEADER,
   EVENT_METADATA_HEADER,
@@ -119,4 +120,60 @@ test('buildConfigSnapshot tolerates empty input', () => {
   const snapshot = buildConfigSnapshot()
   assert.deepEqual(snapshot.algorithms, [])
   assert.equal(snapshot.encoder, null)
+})
+
+// ── summarizeRunCompletion ────────────────────────────────────────────────
+const ALGOS = ['ocl-search', 'ocl-semantic']
+
+test('all rows done → completed, full count', () => {
+  const rowStages = { 0: {'ocl-search': 1, 'ocl-semantic': 1}, 1: {'ocl-search': 1, 'ocl-semantic': 1} }
+  const r = summarizeRunCompletion({ rowStages, rowIndices: [0, 1], algoIds: ALGOS })
+  assert.deepEqual(r, { completed_rows: 2, failed_rows: 0, completion_status: 'completed' })
+})
+
+test('a row counts completed if ANY attempted algo finished (mixed done+failed)', () => {
+  const rowStages = { 0: {'ocl-search': 1, 'ocl-semantic': -2} }
+  const r = summarizeRunCompletion({ rowStages, rowIndices: [0], algoIds: ALGOS })
+  assert.equal(r.completed_rows, 1)
+  assert.equal(r.failed_rows, 0)
+})
+
+test('a row counts failed only when EVERY attempted algo failed', () => {
+  const rowStages = { 0: {'ocl-search': -2, 'ocl-semantic': -2}, 1: {'ocl-search': 1, 'ocl-semantic': 1} }
+  const r = summarizeRunCompletion({ rowStages, rowIndices: [0, 1], algoIds: ALGOS })
+  assert.deepEqual(r, { completed_rows: 1, failed_rows: 1, completion_status: 'partial' })
+})
+
+test('all rows failed → failed', () => {
+  const rowStages = { 0: {'ocl-search': -2}, 1: {'ocl-search': -2} }
+  const r = summarizeRunCompletion({ rowStages, rowIndices: [0, 1], algoIds: ['ocl-search'] })
+  assert.deepEqual(r, { completed_rows: 0, failed_rows: 2, completion_status: 'failed' })
+})
+
+test('cancelled run does NOT over-report: unattempted rows count as neither (review #2)', () => {
+  // rows 0,1 finished; rows 2,3 never reached (stage -1) before the user cancelled.
+  const rowStages = {
+    0: {'ocl-search': 1, 'ocl-semantic': 1},
+    1: {'ocl-search': 1, 'ocl-semantic': 1},
+    2: {'ocl-search': -1, 'ocl-semantic': -1},
+    3: {'ocl-search': -1, 'ocl-semantic': -1},
+  }
+  const r = summarizeRunCompletion({ rowStages, rowIndices: [0, 1, 2, 3], algoIds: ALGOS, aborted: true })
+  assert.equal(r.completed_rows, 2, 'only the 2 finished rows count as completed')
+  assert.equal(r.failed_rows, 0)
+  assert.equal(r.completion_status, 'cancelled')
+})
+
+test('in-flight rows (stage 0) at cancel count as neither completed nor failed', () => {
+  const rowStages = { 0: {'ocl-search': 1}, 1: {'ocl-search': 0} }
+  const r = summarizeRunCompletion({ rowStages, rowIndices: [0, 1], algoIds: ['ocl-search'], aborted: true })
+  assert.equal(r.completed_rows, 1)
+  assert.equal(r.failed_rows, 0)
+  assert.equal(r.completion_status, 'cancelled')
+})
+
+test('rows missing from rowStages are treated as unattempted', () => {
+  const r = summarizeRunCompletion({ rowStages: { 0: {'ocl-search': 1} }, rowIndices: [0, 9], algoIds: ['ocl-search'] })
+  assert.equal(r.completed_rows, 1)
+  assert.equal(r.completion_status, 'partial') // row 9 never ran → completed < total
 })

--- a/src/services/__tests__/attribution.test.js
+++ b/src/services/__tests__/attribution.test.js
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for the attribution header/config builders (ocl_online#105 Phase 5).
+ *
+ * Run with: npm test
+ *
+ * The contract under test is the server-side parser
+ * (core/common/attribution.py, mirrored in ocl-ai-assistant + ocl-analytics-api)
+ * and the vocabulary docs
+ * (ocl-online-docs/conventions/{request-source,event-metadata}-vocabulary.md):
+ * one discrete request_source header + one single-line, string-valued JSON bag,
+ * with row_indices the sole array value.
+ */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildAttributionHeaders,
+  buildConfigSnapshot,
+  REQUEST_SOURCE,
+  REQUEST_SOURCE_HEADER,
+  EVENT_METADATA_HEADER,
+} from '../attribution.js'
+
+const meta = headers => JSON.parse(headers[EVENT_METADATA_HEADER])
+
+test('scalar run: automatch source + string-valued bag', () => {
+  const h = buildAttributionHeaders({ runId: 4827, projectId: 139, rowIndex: 141, algorithmId: 'ocl-semantic' })
+  assert.equal(h[REQUEST_SOURCE_HEADER], REQUEST_SOURCE.AUTOMATCH)
+  assert.deepEqual(meta(h), {
+    automatch_run_id: '4827',
+    map_project_id: '139',
+    row_index: '141',
+    algorithm_id: 'ocl-semantic',
+  })
+})
+
+test('every scalar value is a JSON string, not a number', () => {
+  const m = meta(buildAttributionHeaders({ runId: 1, projectId: 2, rowIndex: 3, algorithmId: 'x', clientAttemptN: 2 }))
+  Object.entries(m).forEach(([key, value]) => {
+    assert.equal(typeof value, 'string', `${key} should be a string`)
+  })
+})
+
+test('batch>1: row_indices int array + string batch_size, no scalar row_index', () => {
+  const m = meta(buildAttributionHeaders({ runId: 9, projectId: 5, rowIndices: [1, 2, 3], batchSize: 3, algorithmId: 'ocl-search' }))
+  assert.deepEqual(m.row_indices, [1, 2, 3])
+  assert.equal(m.batch_size, '3')
+  assert.ok(!('row_index' in m), 'batched call must NOT carry a scalar row_index')
+})
+
+test('batch_size defaults to rowIndices length when omitted', () => {
+  const m = meta(buildAttributionHeaders({ runId: 9, projectId: 5, rowIndices: [4, 5] }))
+  assert.equal(m.batch_size, '2')
+})
+
+test('single-element rowIndices collapses to a scalar row_index (batch=1 rule)', () => {
+  const m = meta(buildAttributionHeaders({ runId: 9, projectId: 5, rowIndices: [7], algorithmId: 'ocl-ciel-bridge' }))
+  assert.equal(m.row_index, '7')
+  assert.ok(!('row_indices' in m))
+  assert.ok(!('batch_size' in m))
+})
+
+test('manual call (no runId): mapper-ui-manual + no automatch_run_id', () => {
+  const h = buildAttributionHeaders({ projectId: 139, rowIndex: 12 })
+  assert.equal(h[REQUEST_SOURCE_HEADER], REQUEST_SOURCE.MANUAL)
+  const m = meta(h)
+  assert.ok(!('automatch_run_id' in m))
+  assert.equal(m.map_project_id, '139')
+  assert.equal(m.row_index, '12')
+})
+
+test('null/undefined fields are omitted from the bag', () => {
+  const m = meta(buildAttributionHeaders({ runId: 1, projectId: 2, rowIndex: null, algorithmId: undefined }))
+  assert.deepEqual(Object.keys(m).sort(), ['automatch_run_id', 'map_project_id'])
+})
+
+test('event metadata is single-line and round-trips through JSON.parse', () => {
+  const raw = buildAttributionHeaders({ runId: 1, projectId: 2, rowIndices: [1, 2], batchSize: 2 })[EVENT_METADATA_HEADER]
+  assert.ok(!raw.includes('\n'), 'bag must be single-line')
+  assert.doesNotThrow(() => JSON.parse(raw))
+})
+
+test('explicit source overrides the runId-derived value', () => {
+  const h = buildAttributionHeaders({ runId: 5, projectId: 2, rowIndex: 1, source: REQUEST_SOURCE.MANUAL })
+  assert.equal(h[REQUEST_SOURCE_HEADER], REQUEST_SOURCE.MANUAL)
+  // the run id is still recorded in the bag even when the source is overridden
+  assert.equal(meta(h).automatch_run_id, '5')
+})
+
+test('client_attempt_n is recorded as a string when provided', () => {
+  const m = meta(buildAttributionHeaders({ runId: 1, projectId: 2, rowIndex: 0, clientAttemptN: 3 }))
+  assert.equal(m.client_attempt_n, '3')
+})
+
+test('empty input is valid: manual source + empty bag', () => {
+  const h = buildAttributionHeaders()
+  assert.equal(h[REQUEST_SOURCE_HEADER], REQUEST_SOURCE.MANUAL)
+  assert.deepEqual(meta(h), {})
+})
+
+test('buildConfigSnapshot strips function-valued algo fields and is JSON-serializable', () => {
+  const snapshot = buildConfigSnapshot({
+    selectedAlgos: [{ id: 'ocl-semantic', name: 'Semantic', batch_size: 10, getIcon: () => 'icon' }],
+    encoderModel: 'enc-1',
+    scoreConfig: { recommended: 99, available: 70 },
+    filters: { source: 'CIEL' },
+    template: { key: 't', version: '1' },
+    aiModel: 'claude-haiku',
+  })
+  assert.deepEqual(snapshot.algorithms, [{ id: 'ocl-semantic', name: 'Semantic', batch_size: 10 }])
+  assert.equal(snapshot.encoder, 'enc-1')
+  assert.deepEqual(snapshot.score_config, { recommended: 99, available: 70 })
+  assert.equal(snapshot.ai_model, 'claude-haiku')
+  assert.doesNotThrow(() => JSON.stringify(snapshot))
+})
+
+test('buildConfigSnapshot tolerates empty input', () => {
+  const snapshot = buildConfigSnapshot()
+  assert.deepEqual(snapshot.algorithms, [])
+  assert.equal(snapshot.encoder, null)
+})

--- a/src/services/attribution.js
+++ b/src/services/attribution.js
@@ -18,6 +18,8 @@
  * consumer hint that maps a batched backend call to the rows it covered).
  */
 
+import isFunction from 'lodash/isFunction.js'
+
 export const REQUEST_SOURCE = {
   AUTOMATCH: 'automatch',
   MANUAL: 'mapper-ui-manual',
@@ -83,8 +85,6 @@ export const buildAttributionHeaders = ({
   }
 }
 
-const isFunction = value => typeof value === 'function'
-
 /**
  * Assemble the JSON-safe project config captured at run start
  * (AutomatchRun.config_snapshot). Strips function-valued algorithm fields
@@ -119,3 +119,44 @@ export const buildConfigSnapshot = ({
   template: template || null,
   ai_model: aiModel || null,
 })
+
+/**
+ * Derive AutomatchRun completion counts + status from the per-row algo stages
+ * captured during a run (oclapi2 PATCH /auto-match-runs/<id>/).
+ *
+ * Stage vocabulary (oclmap rowStageRef): -2 failed, -1 not run yet, 0 running,
+ * 1 done. A row is **completed** when ANY attempted algo finished (1) and
+ * **failed** when EVERY attempted algo failed (-2). Rows that never ran
+ * (-1/undefined — e.g. a run cancelled before reaching them) or were still in
+ * flight (0) count as NEITHER, so a cancelled run never over-reports
+ * completed_rows (ocl_online#115 review).
+ *
+ * @param {object}   [opts]
+ * @param {object[]} [opts.rowStages]  array indexed by row __index → {algoId: stage}
+ * @param {number[]} [opts.rowIndices] the run's intended row indices
+ * @param {string[]} [opts.algoIds]    the selected match-algorithm ids
+ * @param {boolean}  [opts.aborted]    whether the run was cancelled
+ * @returns {{completed_rows:number, failed_rows:number, completion_status:string}}
+ */
+export const summarizeRunCompletion = ({
+  rowStages = [],
+  rowIndices = [],
+  algoIds = [],
+  aborted = false,
+} = {}) => {
+  let completed = 0
+  let failed = 0
+  rowIndices.forEach(idx => {
+    const stage = rowStages[idx] || {}
+    const attempted = algoIds.map(id => stage[id]).filter(s => s !== undefined && s !== -1)
+    if(!attempted.length) return
+    if(attempted.some(s => s === 1)) completed += 1
+    else if(attempted.every(s => s === -2)) failed += 1
+  })
+  const total = rowIndices.length
+  let completion_status = 'completed'
+  if(aborted) completion_status = 'cancelled'
+  else if(completed === 0) completion_status = 'failed'
+  else if(completed < total) completion_status = 'partial'
+  return { completed_rows: completed, failed_rows: failed, completion_status }
+}

--- a/src/services/attribution.js
+++ b/src/services/attribution.js
@@ -1,0 +1,121 @@
+/**
+ * Cross-process attribution (ocl_online#105 Phase 5).
+ *
+ * Builds the two propagation headers the deployed middleware reads:
+ *   - X-OCL-Request-Source : the typed slicer (its own discrete header so it
+ *                            never depends on JSON parsing)
+ *   - X-OCL-Event-Metadata : one bundled, single-line, string-valued JSON bag
+ *
+ * Vocabulary source of truth (lower-kebab-case values, lower-snake-case keys):
+ *   ocl-online-docs/conventions/request-source-vocabulary.md
+ *   ocl-online-docs/conventions/event-metadata-vocabulary.md
+ *
+ * The server-side parser (core/common/attribution.py, mirrored in
+ * ocl-ai-assistant + ocl-analytics-api) does `json.loads` then compares
+ * `event_metadata->>'<key>'` to the raw filter param — a TEXT comparison — so
+ * every SCALAR value MUST be a JSON string ("row_index":"141", not 141).
+ * `row_indices` is the single exception: a JSON array of ints (a non-indexed
+ * consumer hint that maps a batched backend call to the rows it covered).
+ */
+
+export const REQUEST_SOURCE = {
+  AUTOMATCH: 'automatch',
+  MANUAL: 'mapper-ui-manual',
+}
+
+export const REQUEST_SOURCE_HEADER = 'X-OCL-Request-Source'
+export const EVENT_METADATA_HEADER = 'X-OCL-Event-Metadata'
+
+const isPresent = value =>
+  value !== null && value !== undefined && !(typeof value === 'number' && Number.isNaN(value))
+
+/**
+ * Build the attribution request headers for a single backend call.
+ *
+ * Manual (non-run) callers pass no `runId`, which yields
+ * `request_source=mapper-ui-manual` and omits `automatch_run_id` — the same
+ * call sites are reused outside an auto-match run (panel open, single rerun).
+ *
+ * @param {object}              [opts]
+ * @param {number|string|null}  [opts.runId]         automatch_run_id (omitted when absent)
+ * @param {number|string|null}  [opts.projectId]     map_project_id
+ * @param {number|null}         [opts.rowIndex]      scalar row index (batch=1)
+ * @param {number[]|null}       [opts.rowIndices]    rows covered by a batched call (batch>1)
+ * @param {number|null}         [opts.batchSize]     backend-call batch size (batch>1)
+ * @param {string|null}         [opts.algorithmId]   algorithm_id (semantic / bridge / reranker / …)
+ * @param {number|null}         [opts.clientAttemptN] retry attempt number, 1-based
+ * @param {string|null}         [opts.source]        explicit request_source override
+ * @returns {Object<string,string>} the two headers
+ */
+export const buildAttributionHeaders = ({
+  runId = null,
+  projectId = null,
+  rowIndex = null,
+  rowIndices = null,
+  batchSize = null,
+  algorithmId = null,
+  clientAttemptN = null,
+  source = null,
+} = {}) => {
+  const requestSource = source || (isPresent(runId) ? REQUEST_SOURCE.AUTOMATCH : REQUEST_SOURCE.MANUAL)
+
+  const meta = {}
+  if(isPresent(runId)) meta.automatch_run_id = String(runId)
+  if(isPresent(projectId)) meta.map_project_id = String(projectId)
+
+  // batch>1 carries the int array + size and NULLs the scalar row_index; batch=1
+  // carries the scalar. Never both (event-metadata-vocabulary.md, OQ4).
+  if(Array.isArray(rowIndices) && rowIndices.length > 1) {
+    meta.row_indices = rowIndices.map(Number)
+    meta.batch_size = String(batchSize || rowIndices.length)
+  } else if(isPresent(rowIndex)) {
+    meta.row_index = String(rowIndex)
+  } else if(Array.isArray(rowIndices) && rowIndices.length === 1) {
+    meta.row_index = String(rowIndices[0])
+  }
+
+  if(isPresent(algorithmId)) meta.algorithm_id = String(algorithmId)
+  if(isPresent(clientAttemptN)) meta.client_attempt_n = String(clientAttemptN)
+
+  return {
+    [REQUEST_SOURCE_HEADER]: requestSource,
+    [EVENT_METADATA_HEADER]: JSON.stringify(meta),
+  }
+}
+
+const isFunction = value => typeof value === 'function'
+
+/**
+ * Assemble the JSON-safe project config captured at run start
+ * (AutomatchRun.config_snapshot). Strips function-valued algorithm fields
+ * (e.g. getIcon) so the POST body serializes cleanly.
+ *
+ * @param {object}        [opts]
+ * @param {object[]}      [opts.selectedAlgos] algorithms selected for the run
+ * @param {string|null}   [opts.encoderModel]  reranker encoder model
+ * @param {object|null}   [opts.scoreConfig]   {recommended, available} thresholds
+ * @param {object|null}   [opts.filters]       active match filters
+ * @param {object|null}   [opts.template]      prompt-template ref (AI runs only)
+ * @param {object|string|null} [opts.aiModel]  selected AI model (AI runs only)
+ */
+export const buildConfigSnapshot = ({
+  selectedAlgos = [],
+  encoderModel = null,
+  scoreConfig = null,
+  filters = null,
+  template = null,
+  aiModel = null,
+} = {}) => ({
+  algorithms: (selectedAlgos || []).map(algo => {
+    const clean = {}
+    Object.keys(algo || {}).forEach(key => {
+      if(!isFunction(algo[key])) clean[key] = algo[key]
+    })
+    return clean
+  }),
+  encoder: encoderModel || null,
+  score_config: scoreConfig || null,
+  filters: filters || null,
+  template: template || null,
+  ai_model: aiModel || null,
+})


### PR DESCRIPTION
Phase 5 (the final implementation phase) of **OpenConceptLab/ocl_online#105** — retrospective process attribution. Closes the chain: the Mapper UI is the writer that creates the run record and stamps the attribution headers the already-deployed middleware reads.

Sub-ticket: **OpenConceptLab/ocl_online#115**.

## What this does
- **Creates an `AutomatchRun`** at auto-match start — `POST <project>/auto-match-runs/` with `intended_rows`, `trigger_source='ui-auto-match'`, and a `config_snapshot` (algorithms, encoder, score thresholds, filters, AI template/model). Captures the returned `id`.
- **Stamps attribution headers on every per-row backend call** — `X-OCL-Request-Source` (discrete) + `X-OCL-Event-Metadata` (single-line, string-valued JSON bag), across `$match`, `$rerank`, **and the read-side** `$resolveReference` + concept-detail GET, plus the AI `$invoke` (keeping the existing discrete idempotency header and adding the discrete prompt-template-key/version headers). `$match` is the one batched call → `row_indices` + `batch_size`; the rest carry a scalar `row_index`.
- **PATCHes the run to a terminal status** (`completed` / `partial` / `failed` / `cancelled`) with `completed_rows` / `failed_rows` at run end — wrapped in `try/finally` so cancel or an unexpected throw still records the run.
- **Manual (non-run) reuse of the same call sites** (panel open, single rerun) emits `request_source=mapper-ui-manual` for free, so cost-by-surface works for manual usage too.

## Key files
- `src/services/attribution.js` (new) — pure `buildAttributionHeaders` (string-valued scalars, `row_indices` int array, null-key omission, manual fallback) + `buildConfigSnapshot` (strips non-serializable algo fields). 13 unit tests in `src/services/__tests__/attribution.test.js`.
- `src/components/map-projects/MapProject.jsx` — `automatchRunRef` + `createAutomatchRun` / `completeAutomatchRun` + the 6 call-site one-liners. Run creation **degrades gracefully** (a failed create never blocks matching).

## Contract verification (against the deployed backends)
- All upstream phases merged + deployed; `/map-projects/<id>/auto-match-runs/` and `/auto-match-runs/<id>/` resolve in prod (403, not 404).
- Live prod CORS preflight on oclapi2 `$match` returns `access-control-allow-headers` including `X-OCL-REQUEST-SOURCE`, `X-OCL-EVENT-METADATA`, `X-OCL-PROMPT-TEMPLATE-KEY/VERSION`, `X-OCL-REQUEST-IDEMPOTENCY-KEY`; ai-assistant settings list the same. Scalars are sent as JSON **strings** because the middleware filters compare `event_metadata->>'key'` (text).
- `eslint` clean; **158 tests pass**; the running webpack dev bundle compiles with the new code.

## Scope notes
- **Scispacy is now attributed** (correcting an earlier wrong assumption — it is NOT a dark lambda). `ocl-scispacy-loinc` runs its own `AnalyticsMiddleware` and records ~2.7k `$match` rows/30d in `api_transactions`; its `$match` is instrumented here, with the CORS + emitter forward-list change in the companion **OpenConceptLab/ocl-scispacy-loinc#3**.
- **Custom `$match` services remain unrecorded by design** — a custom algo POSTs to `algo.url` (external) with no OCL middleware, so there is no `api_transactions` row. Server-side recording is inherently first-party-only; capturing custom/external `$match` at 100% needs an oclmap-side per-call recorder, tracked as a future enhancement under #105. The AutomatchRun aggregate (config_snapshot + completed/failed counts) already covers custom algos at the run level.
- **Bridge `$match`** attribution is supplied here but applied by the **react-bridge-match** premium component — see OpenConceptLab/react-bridge-match#2. Passing the new arg is harmless against the current bundle; full bridge coverage needs that bundle rebuilt + redeployed at `BRIDGE_MATCH_URL`.

## Remaining for #105 to close
1. Merge the react-bridge-match PR (**merged**) + redeploy the hosted bridge bundle; merge **ocl-scispacy-loinc#3** + deploy scispacy.
2. Optional end-to-end smoke (a real auto-match run writes a live `AutomatchRun` row + attributed `api_transactions`/`prompt_executions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

