### PR TITLE
Attribute debounced reranker calls to the auto-match run (ocl_online#115)

### DIFF
--- a/src/components/map-projects/MapProject.jsx
+++ b/src/components/map-projects/MapProject.jsx
@@ -2993,7 +2993,13 @@ const MapProject = () => {
     return result.concept_key
   }
 
-  const rerank = async (_index, isBulk=false) => {
+  // isBulk drives the auto-propose side-effect (setAutoMatched) for the
+  // processRerankWithConcurrency path. isRunTraffic is attribution-only
+  // (ocl_online#105 Phase 5) and defaults to isBulk; the debounced
+  // scheduleRerank path passes isRunTraffic=true WITHOUT isBulk so a bulk-run
+  // rerank is attributed to the run without doubling the setAutoMatched side
+  // effect the explicit bulk call already performs.
+  const rerank = async (_index, isBulk=false, isRunTraffic=isBulk) => {
     const index = isNumber(_index) ? _index : rowIndex
     if(!isNumber(index)) return null
     if(inFlightRerankRef.current.has(index)) {
@@ -3043,7 +3049,7 @@ const MapProject = () => {
         q: query,
         rows: rerankRows,
         ...(encoderModel ? { encoder_model: encoderModel } : {})
-      }, null, attrHeaders({rowIndex: index, algorithmId: 'reranker', isRunTraffic: isBulk}))
+      }, null, attrHeaders({rowIndex: index, algorithmId: 'reranker', isRunTraffic}))
 
       // Write rerank_score into the row's ConceptRows. matchRerankResultToKey
       // throws on canonical-identity miss; surface to the alert state so a
@@ -3119,7 +3125,16 @@ const MapProject = () => {
   const scheduleRerank = (rowIndex) => {
     if(!isNumber(rowIndex)) return
     const stage = rowStageRef.current[rowIndex] || {}
-    if(isBulkMatchRunningRef.current && bulkMatchAlgoIdsRef.current.length > 0) {
+    // ocl_online#105 Phase 5: this debounced path does most of the reranking
+    // during a bulk auto-match (candidates stream in asynchronously, so the
+    // explicit processRerankWithConcurrency call rarely wins the race). Derive
+    // isRunTraffic from the SAME condition that decides bulk-vs-single gating
+    // below and pass it to rerank(), so the $rerank call is attributed to the
+    // active automatch_run_id (algorithm_id 'reranker') instead of defaulting
+    // to mapper-ui-manual. Internally consistent: if we treat this as a
+    // bulk-run rerank for gating, we attribute it to the run.
+    const isRunTraffic = Boolean(isBulkMatchRunningRef.current && bulkMatchAlgoIdsRef.current.length > 0)
+    if(isRunTraffic) {
       // Bulk auto-match: wait until all selected algos are done (success or failed) for this row.
       const allDone = bulkMatchAlgoIdsRef.current.every(id => stage[id] === 1 || stage[id] === -2)
       if(!allDone) return
@@ -3148,7 +3163,9 @@ const MapProject = () => {
       clearTimeout(rerankDebounceRef.current[rowIndex])
     rerankDebounceRef.current[rowIndex] = setTimeout(() => {
       delete rerankDebounceRef.current[rowIndex]
-      rerank(rowIndex)
+      // isBulk=false (don't double the setAutoMatched side-effect the explicit
+      // bulk rerank already performs); isRunTraffic carries the run attribution.
+      rerank(rowIndex, false, isRunTraffic)
     }, RERANK_DEBOUNCE_MS)
   }
   // Keep the forward-ref consumed by mergeIntoRowMatchState fresh so the

--- a/src/services/__tests__/attribution.test.js
+++ b/src/services/__tests__/attribution.test.js
@@ -71,6 +71,26 @@ test('manual call (no runId): mapper-ui-manual + no automatch_run_id', () => {
   assert.equal(m.row_index, '12')
 })
 
+// Regression guard for the ocl_online#115 reranker gap: the debounced
+// scheduleRerank path must attribute $rerank to the run. The 9-row prod
+// verification (automatch_run_id=1) found reranker landing as mapper-ui-manual
+// because the debounced rerank() call dropped the run flag — only the explicit
+// processRerankWithConcurrency call (isBulk=true) was attributed. These pin the
+// two-way contract the MapProject wiring now relies on.
+test('reranker during a run: automatch + algorithm_id=reranker + automatch_run_id', () => {
+  const h = buildAttributionHeaders({ runId: 1, projectId: 138, rowIndex: 2, algorithmId: 'reranker' })
+  assert.equal(h[REQUEST_SOURCE_HEADER], REQUEST_SOURCE.AUTOMATCH)
+  const m = meta(h)
+  assert.equal(m.automatch_run_id, '1')
+  assert.equal(m.algorithm_id, 'reranker')
+})
+
+test('reranker outside a run (manual): mapper-ui-manual + no automatch_run_id', () => {
+  const h = buildAttributionHeaders({ projectId: 138, rowIndex: 2, algorithmId: 'reranker' })
+  assert.equal(h[REQUEST_SOURCE_HEADER], REQUEST_SOURCE.MANUAL)
+  assert.ok(!('automatch_run_id' in meta(h)))
+})
+
 test('null/undefined fields are omitted from the bag', () => {
   const m = meta(buildAttributionHeaders({ runId: 1, projectId: 2, rowIndex: null, algorithmId: undefined }))
   assert.deepEqual(Object.keys(m).sort(), ['automatch_run_id', 'map_project_id'])


### PR DESCRIPTION
## Why

Live 9-row prod verification of the ocl_online#105 attribution chain (`automatch_run_id=1`, project 138 driven through the deployed Mapper) found one gap: **`reranker` was attributed `mapper-ui-manual`**, so only **1 of 9** rerank calls showed up under `?automatch_run_id=1`.

Root cause: `rerank()`'s `isBulk` flag did double duty — the `setAutoMatched` auto-propose side-effect **and** attribution. The explicit `processRerankWithConcurrency` call passes `isBulk=true` (attributed), but during a run candidates stream in asynchronously (scispacy cold-start especially), so the **debounced `scheduleRerank` path does most of the reranking** — and it called `rerank(rowIndex)` with no run flag → `mapper-ui-manual`, no `automatch_run_id`.

## What

- Decouple the two concerns: `rerank(_index, isBulk=false, isRunTraffic=isBulk)`. `isBulk` keeps driving `setAutoMatched`; `isRunTraffic` is attribution-only.
- `scheduleRerank` derives `isRunTraffic` from the **same** `isBulkMatchRunningRef && bulkMatchAlgoIds.length` condition it already gates bulk-vs-single behavior on, and passes it through the debounced call with `isBulk=false` (so the explicit bulk call's `setAutoMatched` isn't doubled).
- Adds reranker run/manual attribution contract tests.

## Verified
- `npm test` 167/167 · `npm run test:integration` 6/6 · eslint clean.
- The rest of the chain verified green in the same run: AutomatchRun create→complete (9/9); semantic/bridge/scispacy `$match`, `$resolveReference` reads, and AI `$invoke` all `automatch` under run 1; 98 api_transactions + 9 prompt_executions queryable by `automatch_run_id=1`.

Bare-references ocl_online#115 — closes after this lands, redeploys, and a re-run confirms `reranker` 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)